### PR TITLE
hotfix/Return CONTROL if redis connection drops

### DIFF
--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -150,7 +150,7 @@ class Client implements ClientInterface
             );
         } catch (\Exception $e) {
             SplitApp::logger()->critical(
-                "An error occured when attempting to log impression for " .
+                "An error occurred when attempting to log impression for " .
                 "feature: $featureName, key: $key"
             );
         }

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -140,13 +140,20 @@ class Client implements ClientInterface
             SplitApp::logger()->critical($e->getTraceAsString());
         }
 
-        $this->logImpression(
-            $matchingKey,
-            $featureName,
-            TreatmentEnum::CONTROL,
-            $impressionLabel,
-            $bucketingKey
-        );
+        try {
+            $this->logImpression(
+                $matchingKey,
+                $featureName,
+                TreatmentEnum::CONTROL,
+                $impressionLabel,
+                $bucketingKey
+            );
+        } catch (\Exception $e) {
+            SplitApp::logger()->critical(
+                "An error occured when attempting to log impression for " .
+                "feature: $featureName, key: $key"
+            );
+        }
         return TreatmentEnum::CONTROL;
     }
 


### PR DESCRIPTION
Solves Issue:  https://github.com/splitio/php-client/issues/68

An exception was being thrown when redis connection dropped, when trying to log an impression with label CONTROL.
If any of redis methods if throwing exceptions, make sure the exception is logged at a critical level and CONTROL is returned.

- [x] update logic
- [x] add test case
- [x] recreated the issue locally by running the following script and stopping redis during execution. (log file attached)

```
while (true) {
    $treatment = $splitClient->getTreatment('some_key', 'all_feature');
    echo "Treatment: $treatment\n";
    sleep(5);
```
[php_redis_issue.txt](https://github.com/splitio/php-client/files/1189513/php_redis_issue.txt)


