### PR TITLE
Downgrade Shared Memory error messages to debug level.

### DIFF
--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -87,13 +87,13 @@ class Client implements ClientInterface
                 return null;
             }
         } catch (SupportSharedMemoryException $se) {
-            SplitApp::logger()->warning($se->getMessage());
+            SplitApp::logger()->debug($se->getMessage());
         } catch (OpenSharedMemoryException $oe) {
-            SplitApp::logger()->warning($oe->getMessage());
+            SplitApp::logger()->debug($oe->getMessage());
         } catch (ReadSharedMemoryException $re) {
-            SplitApp::logger()->error($re->getMessage());
+            SplitApp::logger()->debug($re->getMessage());
         } catch (\Exception $e) {
-            SplitApp::logger()->error($e->getMessage());
+            SplitApp::logger()->debug($e->getMessage());
         }
 
         return $value;
@@ -107,13 +107,13 @@ class Client implements ClientInterface
         try {
             return SharedMemory::write($ikey, $split, $this->smTtl, $this->smMode, $this->smSize);
         } catch (SupportSharedMemoryException $se) {
-            SplitApp::logger()->warning($se->getMessage());
+            SplitApp::logger()->debug($se->getMessage());
         } catch (OpenSharedMemoryException $oe) {
-            SplitApp::logger()->error($oe->getMessage());
+            SplitApp::logger()->debug($oe->getMessage());
         } catch (WriteSharedMemoryException $we) {
-            SplitApp::logger()->error($we->getMessage());
+            SplitApp::logger()->debug($we->getMessage());
         } catch (\Exception $e) {
-            SplitApp::logger()->error($e->getMessage());
+            SplitApp::logger()->debug($e->getMessage());
         }
 
         return false;


### PR DESCRIPTION
Change "error" and "warning" messages in Shared Memory module to be "debug" level messages.

Since the shared module is merely an optimization, things such as a split not being in memory (a cache "miss") shound't result in an error message to appear in the logs.