### PR TITLE
[SDKS-71]: BUG - Return treatment on readonly mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bin/splitio.ini
 php53test.php
 test.php
 .phpcd
+.vscode
 
 #vim backup files
 *.swp

--- a/src/SplitIO/Component/Cache/MetricsCache.php
+++ b/src/SplitIO/Component/Cache/MetricsCache.php
@@ -66,8 +66,8 @@ class MetricsCache
         try {
             return Di::getCache()->incrementKey(self::getCacheKeyForLatencyBucket($metricName, $bucketNumber));
         } catch (\Exception $e) {
-            Split::logger()->warning('Unable to write metrics back to redis.');
-            Split::logger()->warning($e->getMessage());
+            Di::getLogger()->warning('Unable to write metrics back to redis.');
+            Di::getLogger()->warning($e->getMessage());
         }
     }
 

--- a/src/SplitIO/Component/Cache/MetricsCache.php
+++ b/src/SplitIO/Component/Cache/MetricsCache.php
@@ -1,7 +1,6 @@
 <?php
 namespace SplitIO\Component\Cache;
 
-use SplitIO\Split;
 use SplitIO\Component\Common\Di;
 use SplitIO\Component\Cache\KeyFactory;
 

--- a/src/SplitIO/Component/Cache/MetricsCache.php
+++ b/src/SplitIO/Component/Cache/MetricsCache.php
@@ -1,6 +1,7 @@
 <?php
 namespace SplitIO\Component\Cache;
 
+use SplitIO\Split;
 use SplitIO\Component\Common\Di;
 use SplitIO\Component\Cache\KeyFactory;
 
@@ -62,7 +63,12 @@ class MetricsCache
      */
     public static function addLatencyOnBucket($metricName, $bucketNumber)
     {
-        return Di::getCache()->incrementKey(self::getCacheKeyForLatencyBucket($metricName, $bucketNumber));
+        try {
+            return Di::getCache()->incrementKey(self::getCacheKeyForLatencyBucket($metricName, $bucketNumber));
+        } catch (\Exception $e) {
+            Split::logger()->warning('Unable to write metrics back to redis.');
+            Split::logger()->warning($e->getMessage());
+        }
     }
 
     /**

--- a/src/SplitIO/TreatmentImpression.php
+++ b/src/SplitIO/TreatmentImpression.php
@@ -3,6 +3,7 @@ namespace SplitIO;
 
 use SplitIO\Component\Cache\ImpressionCache;
 use SplitIO\Sdk\Impressions\Impression;
+use SplitIO\Component\Common\Di;
 
 class TreatmentImpression
 {
@@ -13,7 +14,7 @@ class TreatmentImpression
     public static function log(Impression $impression)
     {
         try {
-            Split::logger()->debug($impression);
+            Di::getLogger()->debug($impression);
 
             $impressionCache = new ImpressionCache();
             return $impressionCache->addDataToFeature(
@@ -26,8 +27,8 @@ class TreatmentImpression
                 $impression->getBucketingKey()
             );
         } catch (\Exception $e) {
-            Split::logger()->warning('Unable to write impression back to redis.');
-            Split::logger()->warning($e->getMessage());
+            Di::getLogger()->warning('Unable to write impression back to redis.');
+            Di::getLogger()->warning($e->getMessage());
         }
     }
 }

--- a/src/SplitIO/TreatmentImpression.php
+++ b/src/SplitIO/TreatmentImpression.php
@@ -12,17 +12,22 @@ class TreatmentImpression
      */
     public static function log(Impression $impression)
     {
-        Split::logger()->debug($impression);
+        try {
+            Split::logger()->debug($impression);
 
-        $impressionCache = new ImpressionCache();
-        return $impressionCache->addDataToFeature(
-            $impression->getFeature(),
-            $impression->getId(),
-            $impression->getTreatment(),
-            $impression->getTime(),
-            $impression->getChangeNumber(),
-            $impression->getLabel(),
-            $impression->getBucketingKey()
-        );
+            $impressionCache = new ImpressionCache();
+            return $impressionCache->addDataToFeature(
+                $impression->getFeature(),
+                $impression->getId(),
+                $impression->getTreatment(),
+                $impression->getTime(),
+                $impression->getChangeNumber(),
+                $impression->getLabel(),
+                $impression->getBucketingKey()
+            );
+        } catch (\Exception $e) {
+            Split::logger()->warning('Unable to write impression back to redis.');
+            Split::logger()->warning($e->getMessage());
+        }
     }
 }

--- a/tests/Suite/Redis/PRedisReadOnlyMock.php
+++ b/tests/Suite/Redis/PRedisReadOnlyMock.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace SplitIO\Test\Suite\Redis;
+
+use SplitIO\Component\Cache\Storage\Adapter\PRedis;
+
+class PRedisReadOnlyMock
+{
+    private $predis = null;
+
+    public function __construct(PRedis $predis)
+    {
+        $this->predis = $predis;
+    }
+
+
+ /**
+     * @param string $key
+     * @return \SplitIO\Component\Cache\Item
+     */
+    public function getItem($key)
+    {
+        return $this->predis->getItem($key);
+    }
+
+    /**
+     * Returns a traversable set of cache items.
+     *
+     * @param array $keys
+     * An indexed array of keys of items to retrieve.
+     *
+     * @throws \InvalidArgumentException
+     *   If any of the keys in $keys are not a legal value a \Psr\Cache\InvalidArgumentException
+     *   MUST be thrown.
+     *
+     * @return array|\Traversable
+     *   A traversable collection of Cache Items keyed by the cache keys of
+     *   each item. A Cache item will be returned for each key, even if that
+     *   key is not found. However, if no keys are specified then an empty
+     *   traversable MUST be returned instead.
+     */
+    public function getItems(array $keys = array())
+    {
+        return $this->predis->getItems($keys);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed $value
+     * @param int|null $expiration
+     * @return bool
+     */
+    public function addItem($key, $value, $expiration = null)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * @return bool
+     */
+    public function clear()
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * @param $key
+     * @return bool
+     */
+    public function deleteItem($key)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * @param array $keys
+     * @return bool
+     */
+    public function deleteItems(array $keys)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @param int|null $expiration
+     * @return bool
+     */
+    public function save($key, $value, $expiration = null)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * Adds a values to the set value stored at key.
+     * If this value is already in the set, FALSE is returned.
+     *
+     * @param $key
+     * @param $value
+     * @return boolean
+     */
+    public function addItemList($key, $value)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @return mixed
+     */
+    public function removeItemList($key, $value)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     * @return mixed
+     */
+    public function isOnList($key, $value)
+    {
+        return $this->predis->isOnList($key, $value);
+    }
+
+    /**
+     * @param $key
+     * @return mixed
+     */
+    public function getListItems($key)
+    {
+        return $this->predis->getListItems($key);
+    }
+
+    public function getListItemsRandomly($key, $count)
+    {
+        return $this->predis->getListItemsRandomly($key, $count);
+    }
+
+    public function getKeys($pattern = '*')
+    {
+        return $this->predis->getKeys($pattern);
+    }
+
+    public function incrementKey($key)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    public function getSet($key, $value)
+    {
+        return $this->predis->getSet($key, $value);
+    }
+
+    private static function normalizePrefix($prefix)
+    {
+        return $this->predis->normalizePrefix($prefix);
+    }
+
+    public function rightPushQueue($queueName, $item)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+
+    public function saveItemOnList($key, $value)
+    {
+        throw new \Exception('READONLY mode mocked.');
+    }
+}

--- a/tests/Suite/Sdk/SdkClientTest.php
+++ b/tests/Suite/Sdk/SdkClientTest.php
@@ -12,7 +12,6 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
     private function addSplitsInCache()
     {
         $splitChanges = file_get_contents(__DIR__."/files/splitChanges.json");
-        echo $splitChanges;
         $this->assertJson($splitChanges);
 
         $splitCache = new SplitCache();
@@ -22,7 +21,6 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         foreach ($splits as $split) {
             $splitName = $split['name'];
-            echo "NAME: $splitName\n";
             $this->assertTrue($splitCache->addSplit($splitName, json_encode($split)));
         }
     }

--- a/tests/Suite/Sdk/SdkReadOnlyTest.php
+++ b/tests/Suite/Sdk/SdkReadOnlyTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SplitIO\Test\Suite\Sdk;
+
+use SplitIO\Component\Cache\SplitCache;
+use SplitIO\Component\Cache\Storage\Adapter\PRedis;
+use SplitIO\Component\Common\Di;
+use SplitIO\Test\Suite\Redis\PRedisReadOnlyMock;
+use SplitIO\TreatmentImpression;
+use SplitIO\Grammar\Condition\Partition\TreatmentEnum;
+use SplitIO\Sdk\Impressions\Impression;
+use SplitIO\Component\Log\LoggerTrait;
+
+class SdkReadOnlyTest extends \PHPUnit_Framework_TestCase
+{
+    private function addSplitsInCache()
+    {
+        $splitChanges = file_get_contents(__DIR__."/files/splitReadOnly.json");
+        $this->assertJson($splitChanges);
+        $splitCache = new SplitCache();
+        $splitChanges = json_decode($splitChanges, true);
+        $splits = $splitChanges['splits'];
+        foreach ($splits as $split) {
+            $splitName = $split['name'];
+            $this->assertTrue($splitCache->addSplit($splitName, json_encode($split)));
+        }
+    }
+
+    public function testClient()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        $splitFactory = \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+        $splitSdk = $splitFactory->client();
+
+        //Populating the cache.
+        $this->addSplitsInCache();
+
+        //Instantiate PRedis Mocked Cache
+        $predis = new PRedis(array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options));
+        Di::set(Di::KEY_CACHE, new PRedisReadOnlyMock($predis));
+
+        //Assertions
+        $this->assertEquals('on', $splitSdk->getTreatment('valid', 'mockedPRedis'));
+
+        $this->assertEquals('off', $splitSdk->getTreatment('invalid', 'mockedPRedis'));
+
+        $this->assertEquals('control', $splitSdk->getTreatment('invalid', 'mockedPRedisNotExistant'));
+    }
+
+    public function testException()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        $splitFactory = \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+        $splitSdk = $splitFactory->client();
+
+        //Populating the cache.
+        $this->addSplitsInCache();
+
+        //Instantiate PRedis Mocked Cache
+        $predis = new PRedis(array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options));
+        Di::set(Di::KEY_CACHE, new PRedisReadOnlyMock($predis));
+
+        //Initializing mocked logger
+        $logger = $this
+            ->getMockBuilder('\SplitIO\Component\Log\Logger')
+            ->disableOriginalConstructor()
+            ->setMethods(array('warning', 'debug'))
+            ->getMock();
+
+        $logger->expects($this->at(1))
+            ->method('warning')
+            ->with('Unable to write impression back to redis.');
+
+        $logger->expects($this->at(2))
+            ->method('warning')
+            ->with('READONLY mode mocked.');
+
+        $logger->expects($this->exactly(2))
+            ->method('warning');
+
+        Di::set(Di::KEY_LOG, $logger);
+
+        $impression = new Impression(
+            $matchingKey = 'something',
+            $feature = 'something',
+            $treatment = TreatmentEnum::CONTROL,
+            $label = null,
+            $time = null,
+            $changeNumber = -1,
+            $bucketingKey = 'something'
+        );
+
+        TreatmentImpression::log($impression);
+    }
+}

--- a/tests/Suite/Sdk/SdkReadOnlyTest.php
+++ b/tests/Suite/Sdk/SdkReadOnlyTest.php
@@ -9,7 +9,6 @@ use SplitIO\Test\Suite\Redis\PRedisReadOnlyMock;
 use SplitIO\TreatmentImpression;
 use SplitIO\Grammar\Condition\Partition\TreatmentEnum;
 use SplitIO\Sdk\Impressions\Impression;
-use SplitIO\Component\Log\LoggerTrait;
 
 class SdkReadOnlyTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Suite/Sdk/files/splitReadOnly.json
+++ b/tests/Suite/Sdk/files/splitReadOnly.json
@@ -1,0 +1,40 @@
+{
+    "splits": [
+        {
+            "orgId": null,
+            "environment": null,
+            "trafficTypeId": null,
+            "trafficTypeName": null,
+            "name": "mockedPRedis",
+            "seed": -1222652054,
+            "status": "ACTIVE",
+            "killed": false,
+            "defaultTreatment": "off",
+            "conditions": [
+                {
+                    "matcherGroup": {
+                        "combiner": "AND",
+                        "matchers": [
+                            {
+                                "matcherType": "WHITELIST",
+                                "negate": false,
+                                "userDefinedSegmentMatcherData": null,
+                                "whitelistMatcherData": {
+                                    "whitelist": [
+                                        "valid"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "partitions": [
+                        {
+                            "treatment": "on",
+                            "size": 100
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
[SDKS-71: SDK returns control when unable to write the impression back to Redis](https://splitio.atlassian.net/browse/SDKS-71)

- Added catching error when redis is in readonly mode when the method `logImpression` is called.
- Added catching error when redis is in readonly mode when the method `addLatencyOnBucket`is called.
- Added unit test for read only mode in redis.