### PR TITLE
[SDK-68]: Add support for Redis Sentinel

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -43,7 +43,15 @@
             <directory suffix="Test.php">tests/Suite/Matchers/</directory>
             <directory suffix="Test.php">tests/Suite/Metrics/</directory>
             <directory suffix="Test.php">tests/Suite/Sdk/</directory>
+            <directory suffix="Test.php">tests/Suite/Adapter/</directory>
             <directory suffix="Test.php">tests/Suite/Attributes/</directory>
+        </testsuite>
+
+                <testsuite name="redis">
+
+            <directory suffix="Test.php">tests/Suite/Adapter/</directory>
+ 
+
         </testsuite>
 
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,14 +46,6 @@
             <directory suffix="Test.php">tests/Suite/Adapter/</directory>
             <directory suffix="Test.php">tests/Suite/Attributes/</directory>
         </testsuite>
-
-                <testsuite name="redis">
-
-            <directory suffix="Test.php">tests/Suite/Adapter/</directory>
- 
-
-        </testsuite>
-
     </testsuites>
 
 </phpunit>

--- a/src/SplitIO/Component/Initialization/CacheTrait.php
+++ b/src/SplitIO/Component/Initialization/CacheTrait.php
@@ -23,6 +23,7 @@ class CacheTrait
                     'options' => array(
                         'options'      => isset($options['predis-options']) ? $options['predis-options'] : null,
                         'parameters'   => isset($options['predis-parameters']) ? $options['predis-parameters'] : null,
+                        'sentinels'    => isset($options['predis-sentinels']) ? $options['predis-sentinels'] : null,
                     )
                 );
                 break;

--- a/src/SplitIO/Component/Utils/functions.php
+++ b/src/SplitIO/Component/Utils/functions.php
@@ -30,9 +30,7 @@ function getEnvironment()
 function environment($env = null, $set = false)
 {
     if ($env !== null && $set) {
-
         setEnvironment($env);
-
     } elseif ($env !== null && ! $set) {
         if ($env == getEnvironment()) {
             return true;
@@ -96,4 +94,9 @@ function getSplitEventsUrl()
         default:
             return SPLITIO_EVENTS_URL;
     }
+}
+
+function isAssoc($arr)
+{
+    return array_keys($arr) !== range(0, count($arr) - 1);
 }

--- a/src/SplitIO/Sdk.php
+++ b/src/SplitIO/Sdk.php
@@ -70,6 +70,7 @@ class Sdk
         } elseif ($cacheAdapter == 'predis') {
             $_options['predis-options'] = isset($options['options']) ? $options['options'] : null;
             $_options['predis-parameters'] = isset($options['parameters']) ? $options['parameters'] : null;
+            $_options['predis-sentinels'] = isset($options['sentinels']) ? $options['sentinels'] : null;
         } else {
             throw new Exception("A valid cache system is required. Given: $cacheAdapter");
         }

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '5.3.1';
+    const CURRENT = '5.3.2-rc1';
 }

--- a/tests/Suite/Adapter/RedisAdapterTest.php
+++ b/tests/Suite/Adapter/RedisAdapterTest.php
@@ -136,8 +136,7 @@ class RedisAdapterTest extends \PHPUnit_Framework_TestCase
 
     public function testRedisWithSentinels()
     {
-        $this->setExpectedException(\Predis\Response\ServerException::class);
-
+        $this->setExpectedException(ServerException::class);
         $predis = new PRedis(array(
             'sentinels' => ['127.0.0.1'],
             'options' => [
@@ -145,5 +144,7 @@ class RedisAdapterTest extends \PHPUnit_Framework_TestCase
                 'service' => 'master'
             ]
         ));
+
+        $predis->getItem('this_is_a_test_key');
     }
 }

--- a/tests/Suite/Adapter/RedisAdapterTest.php
+++ b/tests/Suite/Adapter/RedisAdapterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace SplitIO\Test\Suite\Adapter;
+
+use SplitIO\Component\Cache\Storage\Adapter\PRedis;
+use SplitIO\Component\Cache\Storage\Exception\AdapterException;
+use \Predis\Response\ServerException;
+
+class RedisAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRedisWithNullValues()
+    {
+        $predis = new PRedis(array());
+        $predis->addItem('this_is_a_test_key', 'this-is-a-test-value');
+        $value = $predis->getItem('this_is_a_test_key');
+        $this->assertEquals('this-is-a-test-value', $value->get());
+        $result = $predis->deleteItem('this_is_a_test_key');
+        $this->assertTrue($result);
+    }
+
+    public function testRedisWithOnlyParameters()
+    {
+        $predis = new PRedis(array(
+            'parameters' => [
+                'scheme' => 'tcp',
+                'host' => 'localhost',
+                'port' => 6379,
+                'timeout' => 881,
+                'database' => 0
+            ]
+        ));
+        $predis->addItem('this_is_a_test_key', 'this-is-a-test-value');
+        $value = $predis->getItem('this_is_a_test_key');
+        $this->assertEquals('this-is-a-test-value', $value->get());
+        $result = $predis->deleteItem('this_is_a_test_key');
+        $this->assertTrue($result);
+    }
+
+    public function testRedisWithParametersAndPrefix()
+    {
+        $predis = new PRedis(array(
+            'parameters' => [
+                'scheme' => 'tcp',
+                'host' => 'localhost',
+                'port' => 6379,
+                'timeout' => 881,
+                'database' => 0
+            ],
+            'options' => [
+                'prefix' => 'test-redis-assertion'
+            ]
+        ));
+        $predis->addItem('this_is_a_test_key', 'this-is-a-test-value');
+        $value = $predis->getItem('this_is_a_test_key');
+        $this->assertEquals('this-is-a-test-value', $value->get());
+        $result = $predis->deleteItem('this_is_a_test_key');
+        $this->assertTrue($result);
+    }
+
+    public function testRedisWithParametersPrefixAndSentinels()
+    {
+        $predis = new PRedis(array(
+            'parameters' => [
+                'scheme' => 'tcp',
+                'host' => 'localhost',
+                'port' => 6379,
+                'timeout' => 881,
+                'database' => 0
+            ],
+            'sentinels' => ['something', 'other'],
+            'options' => [
+                'prefix' => 'test-redis-assertion'
+            ]
+        ));
+        $predis->addItem('this_is_a_test_key', 'this-is-a-test-value');
+        $value = $predis->getItem('this_is_a_test_key');
+        $this->assertEquals('this-is-a-test-value', $value->get());
+        $result = $predis->deleteItem('this_is_a_test_key');
+        $this->assertTrue($result);
+    }
+
+    public function testRedisWithEmptySentinels()
+    {
+        $this->setExpectedException(AdapterException::class, 'At least one sentinel is required.');
+
+        $predis = new PRedis(array(
+            'sentinels' => [],
+        ));
+    }
+
+    public function testRedisWithSentinelsWithoutOptions()
+    {
+        $this->setExpectedException(AdapterException::class, 'Missing replication mode in options.');
+
+        $predis = new PRedis(array(
+            'sentinels' => ['127.0.0.1'],
+        ));
+    }
+
+    public function testRedisWithSentinelsWithoutReplicationOption()
+    {
+        $this->setExpectedException(AdapterException::class, 'Missing replication mode in options.');
+        $predis = new PRedis(array(
+            'sentinels' => ['127.0.0.1'],
+            'options' => [
+            ]
+        ));
+    }
+
+    public function testRedisWithSentinelsWithWrongReplicationOption()
+    {
+        $this->setExpectedException(AdapterException::class, 'Wrong configuration of redis replication.');
+
+        $predis = new PRedis(array(
+            'sentinels' => ['127.0.0.1'],
+            'options' => [
+                'replication' => 'test'
+            ]
+        ));
+    }
+
+    public function testRedisWithSentinelsWithoutServiceOption()
+    {
+        $this->setExpectedException(
+            AdapterException::class,
+            'Master name is required in replication mode for sentinel.'
+        );
+
+        $predis = new PRedis(array(
+            'sentinels' => ['127.0.0.1'],
+            'options' => [
+                'replication' => 'sentinel'
+            ]
+        ));
+    }
+
+    public function testRedisWithSentinels()
+    {
+        $this->setExpectedException(\Predis\Response\ServerException::class);
+
+        $predis = new PRedis(array(
+            'sentinels' => ['127.0.0.1'],
+            'options' => [
+                'replication' => 'sentinel',
+                'service' => 'master'
+            ]
+        ));
+    }
+}

--- a/tests/Suite/Component/UtilsTest.php
+++ b/tests/Suite/Component/UtilsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SplitIO\Test\Suite\Component;
+
+use SplitIO\Component\Utils as SplitIOUtils;
+
+class UtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsAssocWithEmptyAssociativeArray()
+    {
+        $this->assertTrue(SplitIOUtils\isAssoc(array()));
+    }
+
+    public function testIsAssocWithEmptyArray()
+    {
+        $this->assertTrue(SplitIOUtils\isAssoc([]));
+    }
+
+    public function testIsAssocWithIndexedArray()
+    {
+        $this->assertFalse(SplitIOUtils\isAssoc([1, 2, 3, 4]));
+    }
+
+    public function testIsAssocWithAssociativeArray()
+    {
+        $this->assertTrue(SplitIOUtils\isAssoc(['one' => 'one', 'two' => null]));
+    }
+}


### PR DESCRIPTION
[SDK-68: Add support for Redis Sentinel](https://splitio.atlassian.net/browse/SDKS-68)

- Added code to support redis sentinel in configuration object.
- Added tests for redis sentinel adapter.