### PR TITLE
[SDKS-274]: Redis Cluster Support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+5.7.0 (Oct 30, 2018)
+ - Added support for redis cluster.
 5.6.0 (Oct 23, 2018)
  - Added getTreatments method.
 5.5.1 (Oct 9, 2018)

--- a/Detailed-README.md
+++ b/Detailed-README.md
@@ -268,7 +268,7 @@ $sentinels = array(
 );
 
 $options = array(
-    'replication' => 'sentinel',
+    'distributedStrategy' => 'sentinel',
     'service' => 'SERVICE_MASTER_NAME',
     'prefix' => ''
 );
@@ -277,6 +277,38 @@ $options = array(
 $sdkConfig = array(
     'cache' => array('adapter' => 'predis',
                      'sentinels' => $sentinels,
+                     'options' => $options
+                    )
+);
+
+/** Create the Split Client instance. */
+$splitFactory = \SplitIO\Sdk::factory('YOUR_API_KEY', $sdkConfig);
+$splitClient = $splitFactory->client();
+```
+
+Note: We have deprecated `replication` option and replaced it for `distributedStrategy`.
+
+#### Provided PRedis Cache Adapter - sample code for Cluster Support
+```php
+/*** PRedis clusterNodes array */
+//The array below, will corresponds to a list of cluster nodes.
+//It will be loaded as $client = new Predis\Client($clusterNodes, $options);
+
+$clusterNodes = array(
+    'tcp://IP:PORT?timeout=NUMBER',
+    'tcp://IP:PORT?timeout=NUMBER',
+    'tcp://IP:PORT?timeout=NUMBER'
+);
+
+$options = array(
+    'distributedStrategy' => 'cluster',
+    'prefix' => ''
+);
+
+/** SDK options */
+$sdkConfig = array(
+    'cache' => array('adapter' => 'predis',
+                     'clusterNodes' => $clusterNodes,
                      'options' => $options
                     )
 );

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,5 @@
+5.7.0 (Oct 30, 2018)
+ - Added support for redis cluster.
 5.6.0 (Oct 23, 2018)
  - Added getTreatments method.
 5.5.1 (Oct 9, 2018)

--- a/src/SplitIO/Component/Initialization/CacheTrait.php
+++ b/src/SplitIO/Component/Initialization/CacheTrait.php
@@ -21,9 +21,16 @@ class CacheTrait
                 $adapter_config = array(
                     'name' => 'predis',
                     'options' => array(
-                        'options'      => isset($options['predis-options']) ? $options['predis-options'] : null,
-                        'parameters'   => isset($options['predis-parameters']) ? $options['predis-parameters'] : null,
-                        'sentinels'    => isset($options['predis-sentinels']) ? $options['predis-sentinels'] : null,
+                        'options'               => isset($options['predis-options'])
+                            ? $options['predis-options'] : null,
+                        'parameters'            => isset($options['predis-parameters'])
+                            ? $options['predis-parameters'] : null,
+                        'sentinels'             => isset($options['predis-sentinels'])
+                            ? $options['predis-sentinels'] : null,
+                        'clusterNodes'          => isset($options['predis-clusterNodes'])
+                            ? $options['predis-clusterNodes'] : null,
+                        'distributedStrategy'   => isset($options['predis-distributedStrategy'])
+                            ? $options['predis-distributedStrategy'] : null,
                     )
                 );
                 break;

--- a/src/SplitIO/Sdk.php
+++ b/src/SplitIO/Sdk.php
@@ -71,6 +71,9 @@ class Sdk
             $_options['predis-options'] = isset($options['options']) ? $options['options'] : null;
             $_options['predis-parameters'] = isset($options['parameters']) ? $options['parameters'] : null;
             $_options['predis-sentinels'] = isset($options['sentinels']) ? $options['sentinels'] : null;
+            $_options['predis-clusterNodes'] = isset($options['clusterNodes']) ? $options['clusterNodes'] : null;
+            $_options['predis-distributedStrategy'] = isset($options['distributedStrategy'])
+                ? $options['distributedStrategy'] : null;
         } else {
             throw new Exception("A valid cache system is required. Given: $cacheAdapter");
         }

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '5.6.0';
+    const CURRENT = '5.7.0';
 }


### PR DESCRIPTION
# PHP SDK

## Tickets covered:
* [SDKS-274: Redis Cluster Support](https://splitio.atlassian.net/browse/SDKS-274)

## What did you accomplish?
* Added `clusterNodes` in redis configuration to allow sending cluster array.
* Replaced `replication` option to `distributedStrategy` to make sentinel and cluster parity.

## How to test new changes?
* Execute `vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration`

## Extra Notes
* `Detailed-README` was updated in order to have a sample of redis cluster connection.