### PR TITLE
[PHP]: Traffic Allocation 1 bucket off fix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,15 @@
 # PHP SDK
 
 ## Tickets covered:
-* Ticket
+* [PHP: {TITLE}](https://splitio.atlassian.net/browse/SDKS-{NUMBER})
 
 ## What did you accomplish?
 * Bullet 1
 * Bullet 2
 
 ## How to test new changes?
-*
+* Run tests: `vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration`
+* Run linter: `vendor/bin/phpcs --ignore=functions.php --standard=PSR2 src/`
 
 ## Extra Notes
 * Bullet 1

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+5.7.1 (Dec 3, 2018)
+ - Fixed traffic allocation issue on 1%.
 5.7.0 (Nov 14, 2018)
  - Added support for redis cluster.
 5.6.0 (Oct 23, 2018)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-5.7.1 (Dec 3, 2018)
+5.7.1 (Dec 20, 2018)
  - Fixed traffic allocation issue on 1%.
 5.7.0 (Nov 14, 2018)
  - Added support for redis cluster.

--- a/src/SplitIO/Engine/Splitter.php
+++ b/src/SplitIO/Engine/Splitter.php
@@ -13,11 +13,10 @@ class Splitter
      * @param long $seed
      * @return int
      */
-    public static function getBucket($algo, $key, $seed)
+    public function getBucket($algo, $key, $seed)
     {
         $hashFactory = HashFactory::getHashAlgorithm($algo);
         $hash = $hashFactory->getHash($key, $seed);
-
         return abs($hash  % 100) + 1;
     }
 
@@ -29,7 +28,7 @@ class Splitter
      * @param HashAlgorithmEnum $algo
      * @return null|string
      */
-    public static function getTreatment($key, $seed, $partitions, $algo)
+    public function getTreatment($key, $seed, $partitions, $algo)
     {
         $logMsg = "Splitter evaluating partitions ... \n
         Bucketing Key: $key \n

--- a/src/SplitIO/Sdk.php
+++ b/src/SplitIO/Sdk.php
@@ -7,6 +7,8 @@ use SplitIO\Component\Initialization\LoggerTrait;
 use SplitIO\Exception\Exception;
 use SplitIO\Sdk\Factory\LocalhostSplitFactory;
 use SplitIO\Sdk\Factory\SplitFactory;
+use SplitIO\Component\Common\Di;
+use SplitIO\Engine\Splitter;
 
 class Sdk
 {
@@ -40,6 +42,8 @@ class Sdk
             if (isset($options['ipAddress'])) {
                 self::setIP($options['ipAddress']);
             }
+
+            Di::set('splitter', new Splitter());
 
             return new SplitFactory($apiKey, $options);
         }

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -10,7 +10,6 @@ use SplitIO\Component\Memory\Exception\WriteSharedMemoryException;
 use SplitIO\Component\Memory\SharedMemory;
 use SplitIO\Component\Common\Di;
 use SplitIO\Engine;
-use SplitIO\Engine\Splitter;
 use SplitIO\Grammar\Condition\Partition\TreatmentEnum;
 use SplitIO\Grammar\Split;
 use SplitIO\Metrics;
@@ -146,7 +145,6 @@ class Evaluator
                 $result['impression']['changeNumber'] = $split->getChangeNumber();
             } else {
                 Di::setMatcherClient(new MatcherClient($this));
-                Di::set('splitter', new Splitter());
                 $timeStart = Metrics::startMeasuringLatency();
                 $evaluationResult = Engine::getTreatment(
                     $matchingKey,

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -10,6 +10,7 @@ use SplitIO\Component\Memory\Exception\WriteSharedMemoryException;
 use SplitIO\Component\Memory\SharedMemory;
 use SplitIO\Component\Common\Di;
 use SplitIO\Engine;
+use SplitIO\Engine\Splitter;
 use SplitIO\Grammar\Condition\Partition\TreatmentEnum;
 use SplitIO\Grammar\Split;
 use SplitIO\Metrics;
@@ -145,6 +146,7 @@ class Evaluator
                 $result['impression']['changeNumber'] = $split->getChangeNumber();
             } else {
                 Di::setMatcherClient(new MatcherClient($this));
+                Di::set('splitter', new Splitter());
                 $timeStart = Metrics::startMeasuringLatency();
                 $evaluationResult = Engine::getTreatment(
                     $matchingKey,

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '5.7.0';
+    const CURRENT = '5.7.1-rc1';
 }


### PR DESCRIPTION
# PHP SDK

## Tickets covered:
* [PHP: Traffic Allocation 1 bucket off fix](https://splitio.atlassian.net/browse/SDKS-351)

## What did you accomplish?
* Updated Engine to not return default treatments always.
* Added `Splitter` to `Di` for testing purposes.
* Added unit tests to consider resulting bucket in 1.

## How to test new changes?
* Run tests: `vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration`
* Run linter: `vendor/bin/phpcs --ignore=functions.php --standard=PSR2 src/`
