### PR TITLE
[SDKS-524]: Validate the split names for getTreatment and Manager methods	

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+6.0.1 (March , 2019)
+ - Added validation for non-existing split.
 6.0.0 (Feb 8, 2019)
  - Updated Input Sanitization.
  - BREAKING CHANGE: Moved Impressions to single queue approach.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,5 @@
+6.0.1 (March , 2019)
+ - Added validation for non-existing split.
 6.0.0 (Feb 8, 2019)
  - Updated Input Sanitization.
  - BREAKING CHANGE: Moved Impressions to single queue approach.

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -253,18 +253,27 @@ class Client implements ClientInterface
             $impressions = array();
             foreach ($splitNames as $splitName) {
                 try {
-                    $evalResult = $this->evaluator->evalTreatment($matchingKey, $bucketingKey, $splitName, $attributes);
-                    $result[$splitName] = $evalResult['treatment'];
-
-                    // Creates impression
-                    $impressions[] = $this->createImpression(
-                        $matchingKey,
-                        $splitName,
-                        $evalResult['treatment'],
-                        $evalResult['impression']['label'],
-                        $bucketingKey,
-                        $evalResult['impression']['changeNumber']
-                    );
+                    if (!InputValidator::isSplitInCache($splitName, 'getTreatments')) {
+                        $result[$splitName] = TreatmentEnum::CONTROL;
+                    } else {
+                        $evalResult = $this->evaluator->evalTreatment(
+                            $matchingKey,
+                            $bucketingKey,
+                            $splitName,
+                            $attributes
+                        );
+                        $result[$splitName] = $evalResult['treatment'];
+    
+                        // Creates impression
+                        $impressions[] = $this->createImpression(
+                            $matchingKey,
+                            $splitName,
+                            $evalResult['treatment'],
+                            $evalResult['impression']['label'],
+                            $bucketingKey,
+                            $evalResult['impression']['changeNumber']
+                        );
+                    }
                 } catch (\Exception $e) {
                     $result[$splitName] = TreatmentEnum::CONTROL;
                     SplitApp::logger()->critical(

--- a/src/SplitIO/Sdk/Manager/SplitManager.php
+++ b/src/SplitIO/Sdk/Manager/SplitManager.php
@@ -53,7 +53,7 @@ class SplitManager implements SplitManagerInterface
     public function split($featureName)
     {
         $featureName = InputValidator::validateFeatureName($featureName, 'split');
-        if (is_null($featureName)) {
+        if (is_null($featureName) || !InputValidator::isSplitInCache($featureName, 'split')) {
             return null;
         }
 

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '6.0.0';
+    const CURRENT = '6.0.1-rc1';
 }

--- a/tests/Suite/InputValidation/GetTreatmentValidationTest.php
+++ b/tests/Suite/InputValidation/GetTreatmentValidationTest.php
@@ -86,10 +86,15 @@ class GetTreatmentValidationTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo("Key: matchingKey '12345' is not of type string, converting.")
             ));
 
-            $this->assertEquals(
-                'control',
-                $splitSdk->getTreatment(new Key(12345, 'some_bucketing_key'), 'some_feature')
-            );
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatment: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
+
+        $this->assertEquals(
+            'control',
+            $splitSdk->getTreatment(new Key(12345, 'some_bucketing_key'), 'some_feature')
+        );
     }
 
     public function testGetTreatmentWithNullBucketingKeyObject()
@@ -139,11 +144,16 @@ class GetTreatmentValidationTest extends \PHPUnit_Framework_TestCase
             ->with($this->logicalOr(
                 $this->equalTo("Key: bucketingKey '12345' is not of type string, converting.")
             ));
+    
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatment: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
 
-            $this->assertEquals(
-                'control',
-                $splitSdk->getTreatment(new Key('some_matching_key', 12345), 'some_feature')
-            );
+        $this->assertEquals(
+            'control',
+            $splitSdk->getTreatment(new Key('some_matching_key', 12345), 'some_feature')
+        );
     }
 
     public function testGetTreatmentWithNullKey()
@@ -212,6 +222,11 @@ class GetTreatmentValidationTest extends \PHPUnit_Framework_TestCase
             ->with($this->logicalOr(
                 $this->equalTo("getTreatment: key '123456' is not of type string, converting.")
             ));
+
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatment: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
 
         $this->assertEquals('control', $splitSdk->getTreatment(123456, 'some_feature'));
     }
@@ -283,6 +298,11 @@ class GetTreatmentValidationTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo('getTreatment: split name "some_feature  " has extra whitespace, trimming.')
             ));
 
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatment: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
+
         $this->assertEquals('control', $splitSdk->getTreatment("some_key", 'some_feature  '));
     }
 
@@ -333,6 +353,13 @@ class GetTreatmentValidationTest extends \PHPUnit_Framework_TestCase
     {
         $splitSdk = $this->getFactoryClient();
 
-        $this->assertEquals('control', $splitSdk->getTreatment('some_key_non_existant', 'some_feature_non_existant'));
+        $logger = $this->getMockedLogger();
+
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatment: you passed 'sf' that does not exist in this environment, "
+            . "please double check what Splits exist in the web console."));
+
+        $this->assertEquals('control', $splitSdk->getTreatment('some_key_non_existant', 'sf'));
     }
 }

--- a/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
+++ b/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
@@ -83,6 +83,12 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo("Key: matchingKey '12345' is not of type string, converting.")
             ));
 
+        $logger = $this->getMockedLogger();
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatments: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
+
         $treatmentResult = $splitSdk->getTreatments(new Key(12345, 'some_bucketing_key'), array('some_feature'));
 
         $this->assertEquals(1, count(array_keys($treatmentResult)));
@@ -132,6 +138,11 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->with($this->logicalOr(
                 $this->equalTo("Key: bucketingKey '12345' is not of type string, converting.")
             ));
+
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatments: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
 
         $treatmentResult = $splitSdk->getTreatments(new Key('some_matching_key', 12345), array('some_feature'));
 
@@ -190,6 +201,11 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->with($this->logicalOr(
                 $this->equalTo("getTreatments: key '123456' is not of type string, converting.")
             ));
+
+        $logger->expects($this->once())
+        ->method('critical')
+        ->with($this->equalTo("getTreatments: you passed 'some_feature' that does not exist in this environment, "
+            . "please double check what Splits exist in the web console."));
 
         $treatmentResult = $splitSdk->getTreatments(123456, array('some_feature'));
 
@@ -320,6 +336,11 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
                 $this->equalTo('getTreatments: split name "some_feature  " has extra whitespace, trimming.')
             ));
 
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatments: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
+
         $treatmentResult = $splitSdk->getTreatments("some_key", array('some_feature  '));
 
         $this->assertEquals(1, count(array_keys($treatmentResult)));
@@ -338,6 +359,11 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->with($this->logicalOr(
                 $this->equalTo('getTreatments: split name "   some_feature  " has extra whitespace, trimming.')
             ));
+
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatments: you passed 'some_feature' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
 
         $treatmentResult = $splitSdk->getTreatments("some_key", array('   some_feature  '));
 

--- a/tests/Suite/InputValidation/ManagerValidationTest.php
+++ b/tests/Suite/InputValidation/ManagerValidationTest.php
@@ -106,6 +106,13 @@ class ManagerValidationTest extends \PHPUnit_Framework_TestCase
     {
         $splitSdk = $this->getFactoryClient();
 
+        $logger = $this->getMockedLogger();
+
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("split: you passed 'this_is_a_non_existing_split' that does not exist in this environment, "
+                . "please double check what Splits exist in the web console."));
+
         $this->assertEquals(null, $splitSdk->split('this_is_a_non_existing_split'));
     }
 }

--- a/tests/Suite/Sdk/ImpressionWrapperTest.php
+++ b/tests/Suite/Sdk/ImpressionWrapperTest.php
@@ -152,13 +152,7 @@ class ImpressionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('control', $splitSdk->getTreatment('invalidKey', 'iltestNotExistant'));
 
-        $this->assertArrayHasKey('instance-id', $impressionClient->dataLogged);
-        $this->assertEquals($impressionClient->dataLogged['instance-id'], '1.2.3.4');
-        $this->assertEquals($impressionClient->dataLogged['sdk-language-version'], 'php-'.\SplitIO\version());
-        $this->assertArrayHasKey('impression', $impressionClient->dataLogged);
-        $this->assertEquals($impressionClient->dataLogged['impression']->getTreatment(), 'control');
-        $this->assertInstanceOf('SplitIO\Sdk\Impressions\Impression', $impressionClient->dataLogged['impression']);
-        $this->assertArrayHasKey('attributes', $impressionClient->dataLogged);
+        $this->assertNotEquals($impressionClient->dataLogged['impression']->getTreatment(), 'control');
     }
 
     public function testClientWithEmptyIpAddress()

--- a/tests/Suite/Sdk/SdkClientTest.php
+++ b/tests/Suite/Sdk/SdkClientTest.php
@@ -103,7 +103,6 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
         $this->validateLastImpression($redisClient, 'sample_feature', 'invalidKey', 'off');
 
         $this->assertEquals('control', $splitSdk->getTreatment('invalidKey', 'invalid_feature'));
-        $this->validateLastImpression($redisClient, 'invalid_feature', 'invalidKey', 'control');
 
         $this->assertTrue($splitSdk->isTreatment('user1', 'sample_feature', 'on'));
         $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
@@ -259,7 +258,6 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         //Check impressions generated
         $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
-        $this->validateLastImpression($redisClient, 'invalid_feature', 'user1', 'control');
         $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
     }
 
@@ -296,7 +294,6 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         // Check impressions
         $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
-        $this->validateLastImpression($redisClient, 'invalid_feature', 'user1', 'control');
         $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
     }
 
@@ -333,7 +330,6 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         //Check impressions
         $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
-        $this->validateLastImpression($redisClient, 'invalid_feature', 'user1', 'control');
         $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
     }
 }


### PR DESCRIPTION
# PHP SDK

## Tickets covered:
* [SDKS-524: Validate the split names for getTreatment and Manager methods](https://splitio.atlassian.net/browse/SDKS-524)

## What did you accomplish?
* added validation for split in treatment/s and manager calls

## How to test new changes?
* Run tests: `vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration`
* Run linter: `vendor/bin/phpcs --ignore=functions.php --standard=PSR2 src/`
