### PR TITLE
[SDKS-586]: Update EvaluatorResult to return dynamic configs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+6.0.1 (,2019)
+ - Added configurations to Evaluator Result.
 6.0.0 (Feb 8, 2019)
  - Updated Input Sanitization.
  - BREAKING CHANGE: Moved Impressions to single queue approach.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,5 @@
+6.0.1 (,2019)
+ - Added configurations to Evaluator Result.
 6.0.0 (Feb 8, 2019)
  - Updated Input Sanitization.
  - BREAKING CHANGE: Moved Impressions to single queue approach.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -46,6 +46,7 @@
             <directory suffix="Test.php">tests/Suite/Adapter/</directory>
             <directory suffix="Test.php">tests/Suite/Attributes/</directory>
             <directory suffix="Test.php">tests/Suite/InputValidation/</directory>
+            <directory suffix="Test.php">tests/Suite/DynamicConfigurations/</directory>
         </testsuite>
     </testsuites>
 

--- a/src/SplitIO/Engine.php
+++ b/src/SplitIO/Engine.php
@@ -36,7 +36,7 @@ class Engine
 
         $inRollOut = false;
         foreach ($conditions as $condition) {
-            if (!$inRollOut  && $condition->getConditionType() == ConditionTypeEnum::ROLLOUT) {
+            if (!$inRollOut && $condition->getConditionType() == ConditionTypeEnum::ROLLOUT) {
                 if ($split->getTrafficAllocation() < 100) {
                     $bucket = Di::get('splitter')->getBucket(
                         $split->getAlgo(),

--- a/src/SplitIO/Grammar/Split.php
+++ b/src/SplitIO/Grammar/Split.php
@@ -30,6 +30,8 @@ class Split
 
     private $trafficAllocationSeed = null;
 
+    private $configurations = null;
+
     public function __construct(array $split)
     {
         SplitApp::logger()->debug(print_r($split, true));
@@ -46,7 +48,9 @@ class Split
             $split['trafficAllocation'] : self::DEFAULT_TRAFFIC_ALLOCATION;
         $this->trafficAllocationSeed = isset($split['trafficAllocationSeed']) ?
             $split['trafficAllocationSeed'] : null;
-
+        $this->configurations = isset($split['configurations']) && count($split['configurations']) > 0 ?
+            $split['configurations'] : null;
+        
         SplitApp::logger()->info("Constructing Split: ".$this->name);
 
         if (isset($split['conditions']) && is_array($split['conditions'])) {
@@ -157,5 +161,10 @@ class Split
     public function getTrafficAllocationSeed()
     {
         return $this->trafficAllocationSeed;
+    }
+
+    public function getConfigurations()
+    {
+        return $this->configurations;
     }
 }

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -144,6 +144,9 @@ class Evaluator
                 $result['treatment'] = $split->getDefaultTratment();
                 $result['impression']['label'] = ImpressionLabel::KILLED;
                 $result['impression']['changeNumber'] = $split->getChangeNumber();
+                if ((!is_null($split->getConfigurations())) && isset($split->getConfigurations()[$split->getDefaultTratment()])) {
+                    $result['configurations'] = $split->getConfigurations()[$split->getDefaultTratment()];
+                }
             } else {
                 Di::setMatcherClient(new MatcherClient($this));
                 $timeStart = Metrics::startMeasuringLatency();
@@ -170,7 +173,9 @@ class Evaluator
                 $result['metadata']['latency'] = $latency;
                 $result['impression']['label'] = $impressionLabel;
                 $result['impression']['changeNumber'] = $split->getChangeNumber();
-                $result['configurations'] = $split->getConfigurations();
+                if ((!is_null($split->getConfigurations())) && isset($split->getConfigurations()[$treatment])) {
+                    $result['configurations'] = $split->getConfigurations()[$treatment];
+                }
             }
         } else {
             SplitApp::logger()->warning("The SPLIT definition for '$featureName' has not been found'");

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -140,12 +140,14 @@ class Evaluator
 
         $split = $this->fetchSplit($featureName);
         if ($split != null) {
+            $configurations = $split->getConfigurations();
             if ($split->killed()) {
-                $result['treatment'] = $split->getDefaultTratment();
+                $defaultTreatment = $split->getDefaultTratment();
+                $result['treatment'] = $defaultTreatment;
                 $result['impression']['label'] = ImpressionLabel::KILLED;
                 $result['impression']['changeNumber'] = $split->getChangeNumber();
-                if ((!is_null($split->getConfigurations())) && isset($split->getConfigurations()[$split->getDefaultTratment()])) {
-                    $result['configurations'] = $split->getConfigurations()[$split->getDefaultTratment()];
+                if (!is_null($configurations) && isset($configurations[$defaultTreatment])) {
+                    $result['configurations'] = $configurations[$defaultTreatment];
                 }
             } else {
                 Di::setMatcherClient(new MatcherClient($this));
@@ -160,7 +162,11 @@ class Evaluator
     
                 $treatment = $evaluationResult[Engine::EVALUATION_RESULT_TREATMENT];
                 $impressionLabel = $evaluationResult[Engine::EVALUATION_RESULT_LABEL];
-    
+
+                $result['metadata']['latency'] = $latency;
+                $result['impression']['label'] = $impressionLabel;
+                $result['impression']['changeNumber'] = $split->getChangeNumber();
+
                 //If the given key doesn't match on any condition, default treatment is returned
                 if ($treatment == null) {
                     $treatment = $split->getDefaultTratment();
@@ -170,11 +176,8 @@ class Evaluator
                 SplitApp::logger()->info("*Treatment for $matchingKey in {$split->getName()} is: $treatment");
 
                 $result['treatment'] = $treatment;
-                $result['metadata']['latency'] = $latency;
-                $result['impression']['label'] = $impressionLabel;
-                $result['impression']['changeNumber'] = $split->getChangeNumber();
-                if ((!is_null($split->getConfigurations())) && isset($split->getConfigurations()[$treatment])) {
-                    $result['configurations'] = $split->getConfigurations()[$treatment];
+                if (!is_null($configurations) && isset($configurations[$treatment])) {
+                    $result['configurations'] = $configurations[$treatment];
                 }
             }
         } else {

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -135,6 +135,7 @@ class Evaluator
             'metadata' => array(
                 'latency' => null,
             ),
+            'configurations' => null
         );
 
         $split = $this->fetchSplit($featureName);
@@ -169,6 +170,7 @@ class Evaluator
                 $result['metadata']['latency'] = $latency;
                 $result['impression']['label'] = $impressionLabel;
                 $result['impression']['changeNumber'] = $split->getChangeNumber();
+                $result['configurations'] = $split->getConfigurations();
             }
         } else {
             SplitApp::logger()->warning("The SPLIT definition for '$featureName' has not been found'");

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '6.0.0';
+    const CURRENT = '6.0.1-rc1';
 }

--- a/tests/Suite/DynamicConfigurations/EvaluatorTest.php
+++ b/tests/Suite/DynamicConfigurations/EvaluatorTest.php
@@ -10,7 +10,7 @@ use SplitIO\Sdk\Evaluator;
 
 class EvaluatorTest extends \PHPUnit_Framework_TestCase
 {
-    public $split1 = '{"trafficTypeName":"user","name":"mysplittest","trafficAllocation":100,'
+    private $split1 = '{"trafficTypeName":"user","name":"mysplittest","trafficAllocation":100,'
         . '"trafficAllocationSeed":-285565213,"seed":-1992295819,"status":"ACTIVE","killed":false,"'
         . 'defaultTreatment":"off","changeNumber":1494593336752,"algo":2,"conditions":[{"conditionType"'
         . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
@@ -19,7 +19,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         . ':null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions":[{"treatment":"on","size":0}'
         . ',{"treatment":"off","size":100}],"label":"default rule"}]}';
 
-    public $split2 = '{"trafficTypeName":"user","name":"mysplittest2","trafficAllocation":100,"'
+    private $split2 = '{"trafficTypeName":"user","name":"mysplittest2","trafficAllocation":100,"'
         . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":false,'
         . '"defaultTreatment":"off","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
         . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
@@ -29,7 +29,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         . ':[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"default rule"}'
         . '],"configurations":{"on":"{\"color\": \"blue\",\"size\": 13}"}}';
 
-    public $split3 = '{"trafficTypeName":"user","name":"mysplittest3","trafficAllocation":100,"'
+    private $split3 = '{"trafficTypeName":"user","name":"mysplittest3","trafficAllocation":100,"'
         . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":true,'
         . '"defaultTreatment":"killed","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
         . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
@@ -39,7 +39,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         . ':[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"default rule"}'
         . '],"configurations":{"on":"{\"color\": \"blue\",\"size\": 13}"}}';
 
-    public $split4 = '{"trafficTypeName":"user","name":"mysplittest3","trafficAllocation":100,"'
+    private $split4 = '{"trafficTypeName":"user","name":"mysplittest4","trafficAllocation":100,"'
         . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":true,'
         . '"defaultTreatment":"killed","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
         . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'

--- a/tests/Suite/DynamicConfigurations/EvaluatorTest.php
+++ b/tests/Suite/DynamicConfigurations/EvaluatorTest.php
@@ -29,6 +29,27 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         . ':[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"default rule"}'
         . '],"configurations":{"on":"{\"color\": \"blue\",\"size\": 13}"}}';
 
+    public $split3 = '{"trafficTypeName":"user","name":"mysplittest3","trafficAllocation":100,"'
+        . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":true,'
+        . '"defaultTreatment":"killed","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
+        . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
+        . ':"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData'
+        . '":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"'
+        . 'booleanMatcherData":null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions"'
+        . ':[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"default rule"}'
+        . '],"configurations":{"on":"{\"color\": \"blue\",\"size\": 13}"}}';
+
+    public $split4 = '{"trafficTypeName":"user","name":"mysplittest3","trafficAllocation":100,"'
+        . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":true,'
+        . '"defaultTreatment":"killed","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
+        . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
+        . ':"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData'
+        . '":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"'
+        . 'booleanMatcherData":null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions"'
+        . ':[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"default rule"}'
+        . '],"configurations":{"killed":"{\"color\": \"orange\",\"size\": 13}",'
+        . '"on":"{\"color\": \"blue\",\"size\": 13}"}}';
+
     public function testSplitWithoutConfigurations()
     {
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
@@ -80,8 +101,64 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         $result = $evaluator->evalTreatment('test', '', 'mysplittest2', null);
 
         $this->assertEquals('on', $result['treatment']);
-        $this->assertEquals($result['configurations']['on'], '{"color": "blue","size": 13}');
+        $this->assertEquals($result['configurations'], '{"color": "blue","size": 13}');
 
         $redisClient->del('SPLITIO.split.mysplittest2');
+    }
+
+    public function testSplitWithConfigurationsButKilled()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+
+        $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
+
+        $redisClient->del('SPLITIO.split.mysplittest3');
+
+        $redisClient->set('SPLITIO.split.mysplittest3', $this->split3);
+
+        $evaluator = new Evaluator($options);
+        $result = $evaluator->evalTreatment('test', '', 'mysplittest3', null);
+
+        $this->assertEquals('killed', $result['treatment']);
+        $this->assertEquals($result['configurations'], null);
+
+        $redisClient->del('SPLITIO.split.mysplittest3');
+    }
+
+    public function testSplitWithConfigurationsButKilledWithConfigsOnDefault()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+
+        $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
+
+        $redisClient->del('SPLITIO.split.mysplittest4');
+
+        $redisClient->set('SPLITIO.split.mysplittest4', $this->split4);
+
+        $evaluator = new Evaluator($options);
+        $result = $evaluator->evalTreatment('test', '', 'mysplittest4', null);
+
+        $this->assertEquals('killed', $result['treatment']);
+        $this->assertEquals($result['configurations'], '{"color": "orange","size": 13}');
+
+        $redisClient->del('SPLITIO.split.mysplittest4');
     }
 }

--- a/tests/Suite/DynamicConfigurations/EvaluatorTest.php
+++ b/tests/Suite/DynamicConfigurations/EvaluatorTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace SplitIO\Test\Suite\Sdk;
+
+use SplitIO\Component\Common\Di;
+use SplitIO\Test\Suite\Redis\ReflectiveTools;
+use SplitIO\Component\Cache\SplitCache;
+use SplitIO\Split as SplitApp;
+use SplitIO\Grammar\Split;
+use SplitIO\Sdk\Evaluator;
+
+class EvaluatorTest extends \PHPUnit_Framework_TestCase
+{
+    public $split1 = '{"trafficTypeName":"user","name":"mysplittest","trafficAllocation":100,'
+        . '"trafficAllocationSeed":-285565213,"seed":-1992295819,"status":"ACTIVE","killed":false,"'
+        . 'defaultTreatment":"off","changeNumber":1494593336752,"algo":2,"conditions":[{"conditionType"'
+        . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
+        . ':"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData":null,'
+        . '"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"booleanMatcherData"'
+        . ':null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions":[{"treatment":"on","size":0}'
+        . ',{"treatment":"off","size":100}],"label":"default rule"}]}';
+
+    public $split2 = '{"trafficTypeName":"user","name":"mysplittest2","trafficAllocation":100,"'
+        . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":false,'
+        . '"defaultTreatment":"off","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
+        . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
+        . ':"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData'
+        . '":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"'
+        . 'booleanMatcherData":null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions"'
+        . ':[{"treatment":"on","size":100},{"treatment":"off","size":0}],"label":"default rule"}'
+        . '],"configurations":{"on":"{\"color\": \"blue\",\"size\": 13}"}}';
+
+    public function testSplitWithoutConfigurations()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+
+        $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
+
+        $redisClient->del('SPLITIO.split.mysplittest');
+
+        $redisClient->set('SPLITIO.split.mysplittest', $this->split1);
+
+        $evaluator = new Evaluator($options);
+        $result = $evaluator->evalTreatment('test', '', 'mysplittest', null);
+
+        $this->assertEquals('off', $result['treatment']);
+        $this->assertEquals(null, $result['configurations']);
+
+        $redisClient->del('SPLITIO.split.mysplittest');
+    }
+
+    public function testSplitWithConfigurations()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+
+        $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
+
+        $redisClient->del('SPLITIO.split.mysplittest2');
+
+        $redisClient->set('SPLITIO.split.mysplittest2', $this->split2);
+
+        $evaluator = new Evaluator($options);
+        $result = $evaluator->evalTreatment('test', '', 'mysplittest2', null);
+
+        $this->assertEquals('on', $result['treatment']);
+        $this->assertEquals($result['configurations']['on'], '{"color": "blue","size": 13}');
+
+        $redisClient->del('SPLITIO.split.mysplittest2');
+    }
+}

--- a/tests/Suite/DynamicConfigurations/SplitTest.php
+++ b/tests/Suite/DynamicConfigurations/SplitTest.php
@@ -1,0 +1,94 @@
+<?php
+namespace SplitIO\Test\Suite\Sdk;
+
+use SplitIO\Component\Common\Di;
+use SplitIO\Test\Suite\Redis\ReflectiveTools;
+use SplitIO\Component\Cache\SplitCache;
+use SplitIO\Split as SplitApp;
+use SplitIO\Grammar\Split;
+
+class SplitTest extends \PHPUnit_Framework_TestCase
+{
+    public $split1 = '{"trafficTypeName":"user","name":"mysplittest","trafficAllocation":100,'
+        . '"trafficAllocationSeed":-285565213,"seed":-1992295819,"status":"ACTIVE","killed":false,"'
+        . 'defaultTreatment":"off","changeNumber":1494593336752,"algo":2,"conditions":[{"conditionType"'
+        . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
+        . ':"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData":null,'
+        . '"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"booleanMatcherData"'
+        . ':null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions":[{"treatment":"on","size":0}'
+        . ',{"treatment":"off","size":100}],"label":"default rule"}]}';
+
+    public $split2 = '{"trafficTypeName":"user","name":"mysplittest2","trafficAllocation":100,"'
+        . 'trafficAllocationSeed":1252392550,"seed":971538037,"status":"ACTIVE","killed":false,'
+        . '"defaultTreatment":"off","changeNumber":1494593352077,"algo":2,"conditions":[{"conditionType"'
+        . ':"ROLLOUT","matcherGroup":{"combiner":"AND","matchers":[{"keySelector":{"trafficType"'
+        . ':"user","attribute":null},"matcherType":"ALL_KEYS","negate":false,"userDefinedSegmentMatcherData'
+        . '":null,"whitelistMatcherData":null,"unaryNumericMatcherData":null,"betweenMatcherData":null,"'
+        . 'booleanMatcherData":null,"dependencyMatcherData":null,"stringMatcherData":null}]},"partitions"'
+        . ':[{"treatment":"on","size":0},{"treatment":"off","size":100}],"label":"default rule"}'
+        . '],"configurations":{"on":"{\"color\": \"blue\",\"size\": 13}"}}';
+
+    public function testSplitWithoutConfigurations()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+
+        $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
+
+        $redisClient->del('SPLITIO.split.mysplittest');
+
+        $redisClient->set('SPLITIO.split.mysplittest', $this->split1);
+
+        $splitCacheKey = SplitCache::getCacheKeyForSplit('mysplittest');
+        $splitCachedItem = SplitApp::cache()->getItem($splitCacheKey);
+
+        $splitRepresentation = $splitCachedItem->get();
+
+        $split = new Split(json_decode($splitRepresentation, true));
+
+        $this->assertEquals('mysplittest', $split->getName());
+        $this->assertEquals(null, $split->getConfigurations());
+
+        $redisClient->del('SPLITIO.split.mysplittest');
+    }
+
+    public function testSplitWithConfigurations()
+    {
+        $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
+        $options = array();
+
+        $sdkConfig = array(
+            'log' => array('adapter' => 'stdout'),
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+        );
+
+        //Initializing the SDK instance.
+        \SplitIO\Sdk::factory('asdqwe123456', $sdkConfig);
+
+        $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
+
+        $redisClient->del('SPLITIO.split.mysplittest2');
+
+        $redisClient->set('SPLITIO.split.mysplittest2', $this->split2);
+
+        $splitCacheKey = SplitCache::getCacheKeyForSplit('mysplittest2');
+        $splitCachedItem = SplitApp::cache()->getItem($splitCacheKey);
+
+        $splitRepresentation = $splitCachedItem->get();
+        $split = new Split(json_decode($splitRepresentation, true));
+
+        $this->assertEquals('mysplittest2', $split->getName());
+        $this->assertNotNull($split->getConfigurations());
+        $this->assertEquals($split->getConfigurations()['on'], '{"color": "blue","size": 13}');
+
+        $redisClient->del('SPLITIO.split.mysplittest2');
+    }
+}


### PR DESCRIPTION
# PHP SDK

## Tickets covered:
* [SDKS-586:  Update EvaluatorResult to return dynamic configs](https://splitio.atlassian.net/browse/SDKS-586)

## What did you accomplish?
* added dynamic configurations in evaluator
* updated tests

## How to test new changes?
* Run tests: `vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration`
* Run linter: `vendor/bin/phpcs --ignore=functions.php --standard=PSR2 src/`