### PR TITLE
[SDKS: 577]: Add treatmentsWithConfig method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-6.0.1 (,2019)
+6.1.0 (,2019)
  - Added getTreatmentWithConfig method.
 6.0.0 (Feb 8, 2019)
  - Updated Input Sanitization.

--- a/src/SplitIO/Metrics.php
+++ b/src/SplitIO/Metrics.php
@@ -7,6 +7,8 @@ class Metrics
 {
     const MNAME_SDK_GET_TREATMENT = 'sdk.getTreatment';
     const MNAME_SDK_GET_TREATMENT_WITH_CONFIG = 'sdk.getTreatmentWithConfig';
+    const MNAME_SDK_GET_TREATMENTS = 'sdk.getTreatments';
+    const MNAME_SDK_GET_TREATMENTS_WITH_CONFIG = 'sdk.getTreatmentsWithConfig';
 
     public static function startMeasuringLatency()
     {

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -283,14 +283,16 @@ class Client implements ClientInterface
 
     private function doInputValidationForTreatments($key, $featureNames, array $attributes = null, $operation)
     {
-        $key = InputValidator::validateKey($key, $operation);
-        if (is_null($key)) {
+        $splitNames = InputValidator::validateFeatureNames($featureNames, $operation);
+        if (is_null($splitNames)) {
             return null;
         }
 
-        $splitNames = InputValidator::validateFeatureNames($featureNames, $operation);
-        if (is_null($splitNames) || !InputValidator::validAttributes($attributes, $operation)) {
-            return null;
+        $key = InputValidator::validateKey($key, $operation);
+        if (is_null($key) || !InputValidator::validAttributes($attributes, $operation)) {
+            return array(
+                'controlTreatments' => InputValidator::generateControlTreatments($splitNames),
+            );
         }
 
         return array(
@@ -336,6 +338,9 @@ class Client implements ClientInterface
         $inputValidation = $this->doInputValidationForTreatments($key, $featureNames, $attributes, 'getTreatments');
         if (is_null($inputValidation)) {
             return null;
+        }
+        if (isset($inputValidation['controlTreatments'])) {
+            return $inputValidation['controlTreatments'];
         }
 
         $matchingKey = $inputValidation['matchingKey'];

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -541,7 +541,7 @@ class Client implements ClientInterface
             );
         } catch (\Exception $e) {
             SplitApp::logger()->critical('getTreatmentsWithConfig method is throwing exceptions');
-            $splitNames = InputValidator::validateFeatureNames($featureNames, 'getTreatments');
+            $splitNames = InputValidator::validateFeatureNames($featureNames, 'getTreatmentsWithConfig');
             return !is_null($splitNames) ? InputValidator::generateControlTreatments($splitNames) : array();
         }
     }

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -486,12 +486,6 @@ class Client implements ClientInterface
         } catch (\Exception $e) {
             SplitApp::logger()->critical('getTreatmens method is throwing exceptions');
             $splitNames = InputValidator::validateFeatureNames($featureNames, 'getTreatments');
-            return array_map(
-                function ($feature) {
-                    return $feature['treatment'];
-                },
-                InputValidator::generateControlTreatments($splitNames)
-            );
             return !is_null($splitNames) ?
             array_map(
                 function ($feature) {

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -129,7 +129,7 @@ class Client implements ClientInterface
     {
         $default = array(
             'treatment' => TreatmentEnum::CONTROL,
-            'configurations' => null
+            'config' => null
         );
 
         $inputValidation = $this->doInputValidationForTreatment($key, $featureName, $attributes, $operation);
@@ -171,7 +171,7 @@ class Client implements ClientInterface
 
             return array(
                 'treatment' => $result['treatment'],
-                'configurations' => $result['configurations'],
+                'config' => $result['config'],
             );
         } catch (InvalidMatcherException $ie) {
             SplitApp::logger()->critical('Exception due an INVALID MATCHER');
@@ -260,8 +260,8 @@ class Client implements ClientInterface
 
     /**
      * Returns an object with the treatment to show this id for this feature
-     * and the configurations provided.
-     * The set of treatments and configurations for a feature can be configured
+     * and the config provided.
+     * The set of treatments and config for a feature can be configured
      * on the Split web console.
      * This method returns the string 'control' if:
      * <ol>
@@ -289,7 +289,7 @@ class Client implements ClientInterface
      *
      * This method returns null configuration if:
      * <ol>
-     *     <li>Configurations was not set up</li>
+     *     <li>config was not set up</li>
      * </ol>
      * @param $key
      * @param $featureName
@@ -310,7 +310,7 @@ class Client implements ClientInterface
             SplitApp::logger()->critical('getTreatmentWithConfig method is throwing exceptions');
             return array(
                 'treatment' => TreatmentEnum::CONTROL,
-                'configurations' => null,
+                'config' => null,
             );
         }
     }
@@ -380,7 +380,7 @@ class Client implements ClientInterface
                     $evalResult = $this->evaluator->evalTreatment($matchingKey, $bucketingKey, $splitName, $attributes);
                     $result[$splitName] = array(
                         'treatment' => $evalResult['treatment'],
-                        'configurations' => $evalResult['configurations'],
+                        'config' => $evalResult['config'],
                     );
 
                     $latency += $evalResult['metadata']['latency'];
@@ -397,7 +397,7 @@ class Client implements ClientInterface
                 } catch (\Exception $e) {
                     $result[$splitName] = array(
                         'treatment' => TreatmentEnum::CONTROL,
-                        'configurations' => null,
+                        'config' => null,
                     );
                     SplitApp::logger()->critical(
                         $operation . ': An exception occured when evaluating feature: '. $splitName . '. skipping it'
@@ -498,10 +498,10 @@ class Client implements ClientInterface
 
     /**
      * Returns an associative array which each key will be
-     * the treatment result and the configurations for each
+     * the treatment result and the config for each
      * feature passed as parameter.
      * The set of treatments for a feature can be configured
-     * on the Split web console and the configurations for
+     * on the Split web console and the config for
      * that treatment.
      * This method returns the string 'control' if:
      * <ol>

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -281,6 +281,25 @@ class Client implements ClientInterface
         );
     }
 
+    private function doInputValidationForTreatments($key, $featureNames, array $attributes = null, $operation)
+    {
+        $key = InputValidator::validateKey($key, $operation);
+        if (is_null($key)) {
+            return null;
+        }
+
+        $splitNames = InputValidator::validateFeatureNames($featureNames, $operation);
+        if (is_null($splitNames) || !InputValidator::validAttributes($attributes, $operation)) {
+            return null;
+        }
+
+        return array(
+            'matchingKey' => $key['matchingKey'],
+            'bucketingKey' => $key['bucketingKey'],
+            'featureNames' => $splitNames,
+        );
+    }
+
     /**
      * Returns an associative array which each key will be
      * the treatment result for each feature passed as parameter.
@@ -314,22 +333,14 @@ class Client implements ClientInterface
      */
     public function getTreatments($key, $featureNames, array $attributes = null)
     {
-        $key = InputValidator::validateKey($key, 'getTreatments');
-        if (is_null($key)) {
+        $inputValidation = $this->doInputValidationForTreatments($key, $featureNames, $attributes, 'getTreatments');
+        if (is_null($inputValidation)) {
             return null;
         }
 
-        $splitNames = InputValidator::validateFeatureNames($featureNames);
-        if (is_null($splitNames)) {
-            return null;
-        }
-
-        if (!InputValidator::validAttributes($attributes, 'getTreatments')) {
-            return null;
-        }
-
-        $matchingKey = $key['matchingKey'];
-        $bucketingKey = $key['bucketingKey'];
+        $matchingKey = $inputValidation['matchingKey'];
+        $bucketingKey = $inputValidation['bucketingKey'];
+        $splitNames = $inputValidation['featureNames'];
         
         try {
             $result = array();

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -135,19 +135,19 @@ class Evaluator
             'metadata' => array(
                 'latency' => null,
             ),
-            'configurations' => null
+            'config' => null
         );
 
         $split = $this->fetchSplit($featureName);
         if ($split != null) {
-            $configurations = $split->getConfigurations();
+            $configs = $split->getConfigurations();
             $result['impression']['changeNumber'] = $split->getChangeNumber();
             if ($split->killed()) {
                 $defaultTreatment = $split->getDefaultTratment();
                 $result['treatment'] = $defaultTreatment;
                 $result['impression']['label'] = ImpressionLabel::KILLED;
-                if (!is_null($configurations) && isset($configurations[$defaultTreatment])) {
-                    $result['configurations'] = $configurations[$defaultTreatment];
+                if (!is_null($configs) && isset($configs[$defaultTreatment])) {
+                    $result['config'] = $configs[$defaultTreatment];
                 }
             } else {
                 Di::setMatcherClient(new MatcherClient($this));
@@ -175,8 +175,8 @@ class Evaluator
                 SplitApp::logger()->info("*Treatment for $matchingKey in {$split->getName()} is: $treatment");
 
                 $result['treatment'] = $treatment;
-                if (!is_null($configurations) && isset($configurations[$treatment])) {
-                    $result['configurations'] = $configurations[$treatment];
+                if (!is_null($configs) && isset($configs[$treatment])) {
+                    $result['config'] = $configs[$treatment];
                 }
             }
         } else {

--- a/src/SplitIO/Sdk/Evaluator.php
+++ b/src/SplitIO/Sdk/Evaluator.php
@@ -141,11 +141,11 @@ class Evaluator
         $split = $this->fetchSplit($featureName);
         if ($split != null) {
             $configurations = $split->getConfigurations();
+            $result['impression']['changeNumber'] = $split->getChangeNumber();
             if ($split->killed()) {
                 $defaultTreatment = $split->getDefaultTratment();
                 $result['treatment'] = $defaultTreatment;
                 $result['impression']['label'] = ImpressionLabel::KILLED;
-                $result['impression']['changeNumber'] = $split->getChangeNumber();
                 if (!is_null($configurations) && isset($configurations[$defaultTreatment])) {
                     $result['configurations'] = $configurations[$defaultTreatment];
                 }
@@ -165,8 +165,7 @@ class Evaluator
 
                 $result['metadata']['latency'] = $latency;
                 $result['impression']['label'] = $impressionLabel;
-                $result['impression']['changeNumber'] = $split->getChangeNumber();
-
+                
                 //If the given key doesn't match on any condition, default treatment is returned
                 if ($treatment == null) {
                     $treatment = $split->getDefaultTratment();

--- a/src/SplitIO/Sdk/Validator/InputValidator.php
+++ b/src/SplitIO/Sdk/Validator/InputValidator.php
@@ -5,6 +5,7 @@ namespace SplitIO\Sdk\Validator;
 use SplitIO\Split as SplitApp;
 use SplitIO\Sdk\Key;
 use SplitIO\Component\Utils as SplitIOUtils;
+use SplitIO\Grammar\Condition\Partition\TreatmentEnum;
 
 const MAX_LENGTH = 250;
 const REG_EXP_EVENT_TYPE = "/^[a-zA-Z0-9][-_.:a-zA-Z0-9]{0,79}$/";

--- a/src/SplitIO/Sdk/Validator/InputValidator.php
+++ b/src/SplitIO/Sdk/Validator/InputValidator.php
@@ -274,6 +274,6 @@ class InputValidator
 
     public static function generateControlTreatments($splitNames)
     {
-        return array_fill_keys($splitNames, array('treatment' => TreatmentEnum::CONTROL, 'configurations' => null));
+        return array_fill_keys($splitNames, array('treatment' => TreatmentEnum::CONTROL, 'config' => null));
     }
 }

--- a/src/SplitIO/Sdk/Validator/InputValidator.php
+++ b/src/SplitIO/Sdk/Validator/InputValidator.php
@@ -274,7 +274,6 @@ class InputValidator
 
     public static function generateControlTreatments($splitNames)
     {
-        // return array_fill_keys($splitNames, array('treatment' => TreatmentEnum::CONTROL, 'configurations' => null));
-        return array_fill_keys($splitNames, TreatmentEnum::CONTROL);
+        return array_fill_keys($splitNames, array('treatment' => TreatmentEnum::CONTROL, 'configurations' => null));
     }
 }

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '6.0.1-rc1';
+    const CURRENT = '6.1.0-rc1';
 }

--- a/tests/Suite/DynamicConfigurations/EvaluatorTest.php
+++ b/tests/Suite/DynamicConfigurations/EvaluatorTest.php
@@ -73,7 +73,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         $result = $evaluator->evalTreatment('test', '', 'mysplittest', null);
 
         $this->assertEquals('off', $result['treatment']);
-        $this->assertEquals(null, $result['configurations']);
+        $this->assertEquals(null, $result['config']);
 
         $redisClient->del('SPLITIO.split.mysplittest');
     }
@@ -101,7 +101,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         $result = $evaluator->evalTreatment('test', '', 'mysplittest2', null);
 
         $this->assertEquals('on', $result['treatment']);
-        $this->assertEquals($result['configurations'], '{"color": "blue","size": 13}');
+        $this->assertEquals($result['config'], '{"color": "blue","size": 13}');
 
         $redisClient->del('SPLITIO.split.mysplittest2');
     }
@@ -129,7 +129,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         $result = $evaluator->evalTreatment('test', '', 'mysplittest3', null);
 
         $this->assertEquals('killed', $result['treatment']);
-        $this->assertEquals($result['configurations'], null);
+        $this->assertEquals($result['config'], null);
 
         $redisClient->del('SPLITIO.split.mysplittest3');
     }
@@ -157,7 +157,7 @@ class EvaluatorTest extends \PHPUnit_Framework_TestCase
         $result = $evaluator->evalTreatment('test', '', 'mysplittest4', null);
 
         $this->assertEquals('killed', $result['treatment']);
-        $this->assertEquals($result['configurations'], '{"color": "orange","size": 13}');
+        $this->assertEquals($result['config'], '{"color": "orange","size": 13}');
 
         $redisClient->del('SPLITIO.split.mysplittest4');
     }

--- a/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
+++ b/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
@@ -247,7 +247,7 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo('getTreatments: featureNames must be a non-empty array.'));
 
-        $this->assertEquals(null, $splitSdk->getTreatments('some_key', null, null));
+        $this->assertEquals(array(), $splitSdk->getTreatments('some_key', null, null));
     }
 
     public function testGetTreatmentsWithFeaturesNotArray()
@@ -260,7 +260,7 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo('getTreatments: featureNames must be a non-empty array.'));
 
-        $this->assertEquals(null, $splitSdk->getTreatments('some_key', true, null));
+        $this->assertEquals(array(), $splitSdk->getTreatments('some_key', true, null));
     }
 
     public function testGetTreatmentsWithEmptyFeatures()
@@ -273,7 +273,7 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo('getTreatments: featureNames must be a non-empty array.'));
 
-        $this->assertEquals(null, $splitSdk->getTreatments('some_key', array(), null));
+        $this->assertEquals(array(), $splitSdk->getTreatments('some_key', array(), null));
     }
 
     public function testGetTreatmentsWithNullFeaturesNames()
@@ -293,7 +293,7 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo('getTreatments: featureNames must be a non-empty array.'));
 
-        $this->assertEquals(null, $splitSdk->getTreatments('some_key', array(null, null), null));
+        $this->assertEquals(array(), $splitSdk->getTreatments('some_key', array(null, null), null));
     }
 
     public function testMultipleControlResultsGetTreatments()
@@ -331,7 +331,7 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo('getTreatments: featureNames must be a non-empty array.'));
         
-        $this->assertEquals(null, $splitSdk->getTreatments('some_key', array(true, array()), null));
+        $this->assertEquals(array(), $splitSdk->getTreatments('some_key', array(true, array()), null));
     }
 
     public function testGetTreatmenstWithFeatureNameWithWhitespaces()

--- a/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
+++ b/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
@@ -150,7 +150,9 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo("getTreatments: you passed a null key, key must be a non-empty string."));
 
-        $this->assertEquals(null, $splitSdk->getTreatments(null, array('some_feature')));
+        $result = $splitSdk->getTreatments(null, array('some_feature'));
+        $this->assertEquals(count($result), 1);
+        $this->assertEquals('control', $result['some_feature']);
     }
 
     public function testGetTreatmentsWithEmptyKey()
@@ -163,7 +165,9 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo("getTreatments: you passed an empty key, key must be a non-empty string."));
 
-        $this->assertEquals(null, $splitSdk->getTreatments('', array('some_feature')));
+        $result = $splitSdk->getTreatments('', array('some_feature'));
+        $this->assertEquals(count($result), 1);
+        $this->assertEquals('control', $result['some_feature']);
     }
 
     public function testGetTreatmenstWitNonFiniteKey()
@@ -176,7 +180,9 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo("getTreatments: you passed an invalid key type, key must be a non-empty string."));
 
-        $this->assertEquals(null, $splitSdk->getTreatments(log(0), array('some_feature')));
+        $result = $splitSdk->getTreatments(log(0), array('some_feature'));
+        $this->assertEquals(count($result), 1);
+        $this->assertEquals('control', $result['some_feature']);
     }
 
     public function testGetTreatmentsWitNumberKey()
@@ -226,7 +232,9 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->method('critical')
             ->with($this->equalTo("getTreatments: you passed an invalid key type, key must be a non-empty string."));
 
-        $this->assertEquals(null, $splitSdk->getTreatments(true, array('some_feature')));
+        $result = $splitSdk->getTreatments(true, array('some_feature'));
+        $this->assertEquals(count($result), 1);
+        $this->assertEquals('control', $result['some_feature']);
     }
 
     public function testGetTreatmentsWithNullFeatures()
@@ -286,6 +294,24 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('getTreatments: featureNames must be a non-empty array.'));
 
         $this->assertEquals(null, $splitSdk->getTreatments('some_key', array(null, null), null));
+    }
+
+    public function testMultipleControlResultsGetTreatments()
+    {
+        $splitSdk = $this->getFactoryClient();
+
+        $logger = $this->getMockedLogger();
+
+        $logger->expects($this->once())
+            ->method('critical')
+            ->with($this->equalTo("getTreatments: you passed an invalid key type, key must be a non-empty string."));
+
+        $result = $splitSdk->getTreatments(true, array('some_feature', 'some_feature_3', 'some_feature',
+            'some_feature_2'));
+        $this->assertEquals(count($result), 3);
+        $this->assertEquals('control', $result['some_feature']);
+        $this->assertEquals('control', $result['some_feature_2']);
+        $this->assertEquals('control', $result['some_feature_3']);
     }
 
     public function testGetTreatmentsWithOneWrongTypeOfFeaturesNames()

--- a/tests/Suite/Sdk/SdkClientTest.php
+++ b/tests/Suite/Sdk/SdkClientTest.php
@@ -144,29 +144,29 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
         //Assertions GET_TREATMENT_WITH_CONFIG
         $result = $splitSdk->getTreatmentWithConfig('user1', 'sample_feature');
         $this->assertEquals('on', $result['treatment']);
-        $this->assertEquals('{"size":15,"test":20}', $result['configurations']);
+        $this->assertEquals('{"size":15,"test":20}', $result['config']);
         $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
 
         $result = $splitSdk->getTreatmentWithConfig('invalidKey', 'sample_feature');
         $this->assertEquals('off', $result['treatment']);
-        $this->assertEquals(null, $result['configurations']);
+        $this->assertEquals(null, $result['config']);
         $this->validateLastImpression($redisClient, 'sample_feature', 'invalidKey', 'off');
 
         $result = $splitSdk->getTreatmentWithConfig('invalidKey', 'invalid_feature');
         $this->assertEquals('control', $result['treatment']);
-        $this->assertEquals(null, $result['configurations']);
+        $this->assertEquals(null, $result['config']);
         $this->validateLastImpression($redisClient, 'invalid_feature', 'invalidKey', 'control');
 
         //testing a killed feature. No matter what the key, must return default treatment
         $result = $splitSdk->getTreatmentWithConfig('invalidKey', 'killed_feature');
         $this->assertEquals('defTreatment', $result['treatment']);
-        $this->assertEquals('{"size":15,"defTreatment":true}', $result['configurations']);
+        $this->assertEquals('{"size":15,"defTreatment":true}', $result['config']);
         $this->validateLastImpression($redisClient, 'killed_feature', 'invalidKey', 'defTreatment');
 
         //testing ALL matcher
         $result = $splitSdk->getTreatmentWithConfig('invalidKey', 'all_feature');
         $this->assertEquals('on', $result['treatment']);
-        $this->assertEquals(null, $result['configurations']);
+        $this->assertEquals(null, $result['config']);
         $this->validateLastImpression($redisClient, 'all_feature', 'invalidKey', 'on');
 
         //Assertions GET_TREATMENTS
@@ -214,33 +214,33 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
         $result = $splitSdk->getTreatmentsWithConfig('user1', array('sample_feature'));
         $this->assertEquals(1, count($result));
         $this->assertEquals('on', $result['sample_feature']['treatment']);
-        $this->assertEquals('{"size":15,"test":20}', $result['sample_feature']['configurations']);
+        $this->assertEquals('{"size":15,"test":20}', $result['sample_feature']['config']);
         $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
 
         $result = $splitSdk->getTreatmentsWithConfig('invalidKey', array('sample_feature'));
         $this->assertEquals(1, count($result));
         $this->assertEquals('off', $result['sample_feature']['treatment']);
-        $this->assertEquals(null, $result['sample_feature']['configurations']);
+        $this->assertEquals(null, $result['sample_feature']['config']);
         $this->validateLastImpression($redisClient, 'sample_feature', 'invalidKey', 'off');
 
         $result = $splitSdk->getTreatmentsWithConfig('invalidKey', array('invalid_feature'));
         $this->assertEquals(1, count($result));
         $this->assertEquals('control', $result['invalid_feature']['treatment']);
-        $this->assertEquals(null, $result['invalid_feature']['configurations']);
+        $this->assertEquals(null, $result['invalid_feature']['config']);
         $this->validateLastImpression($redisClient, 'invalid_feature', 'invalidKey', 'control');
 
         //testing a killed feature. No matter what the key, must return default treatment
         $result = $splitSdk->getTreatmentsWithConfig('invalidKey', array('killed_feature'));
         $this->assertEquals(1, count($result));
         $this->assertEquals('defTreatment', $result['killed_feature']['treatment']);
-        $this->assertEquals('{"size":15,"defTreatment":true}', $result['killed_feature']['configurations']);
+        $this->assertEquals('{"size":15,"defTreatment":true}', $result['killed_feature']['config']);
         $this->validateLastImpression($redisClient, 'killed_feature', 'invalidKey', 'defTreatment');
 
         //testing ALL matcher
         $result = $splitSdk->getTreatmentsWithConfig('invalidKey', array('all_feature'));
         $this->assertEquals(1, count($result));
         $this->assertEquals('on', $result['all_feature']['treatment']);
-        $this->assertEquals(null, $result['all_feature']['configurations']);
+        $this->assertEquals(null, $result['all_feature']['config']);
         $this->validateLastImpression($redisClient, 'all_feature', 'invalidKey', 'on');
 
         //testing multiple splitNames
@@ -252,13 +252,13 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
         ));
         $this->assertEquals(4, count($result));
         $this->assertEquals('on', $result['all_feature']['treatment']);
-        $this->assertEquals(null, $result['all_feature']['configurations']);
+        $this->assertEquals(null, $result['all_feature']['config']);
         $this->assertEquals('defTreatment', $result['killed_feature']['treatment']);
-        $this->assertEquals('{"size":15,"defTreatment":true}', $result['killed_feature']['configurations']);
+        $this->assertEquals('{"size":15,"defTreatment":true}', $result['killed_feature']['config']);
         $this->assertEquals('control', $result['invalid_feature']['treatment']);
-        $this->assertEquals(null, $result['invalid_feature']['configurations']);
+        $this->assertEquals(null, $result['invalid_feature']['config']);
         $this->assertEquals('off', $result['sample_feature']['treatment']);
-        $this->assertEquals(null, $result['sample_feature']['configurations']);
+        $this->assertEquals(null, $result['sample_feature']['config']);
     }
 
     /**


### PR DESCRIPTION
# PHP SDK

## Tickets covered:
* [SDKS: 577: Add treatmentsWithConfig method](https://splitio.atlassian.net/browse/SDKS-577)

## What did you accomplish?
* Refactored `getTreatments` call.
* Added logic to return control treatments when input validation rejects `getTreatments` call.
* Added `getTreatmentsWithConfig` method.
* Updated tests

## How to test new changes?
* Run tests: `vendor/bin/phpunit -c phpunit.xml.dist --testsuite integration`
* Run linter: `vendor/bin/phpcs --ignore=functions.php --standard=PSR2 src/`