### PR TITLE
Feature/do not send ip

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+6.2.3 (Oct XX, 2019)
+ - Added flag `IPAddressesEnabled` into options to enable/disable sending MachineName and MachineIP when data is posted in headers.
+
 6.2.2 (Sep 18, 2019)
  - Fetch multiple splits at once on getTreatments/getTreatmentsWithConfig
  - Removed MatcherClient (DependencyMatcher now uses Evaluator directly)

--- a/src/SplitIO/Component/Cache/ImpressionCache.php
+++ b/src/SplitIO/Component/Cache/ImpressionCache.php
@@ -3,22 +3,19 @@ namespace SplitIO\Component\Cache;
 
 use SplitIO\Component\Common\Di;
 use SplitIO\Component\Cache\KeyFactory;
+use SplitIO\Sdk\QueueMetadataMessage;
 
 class ImpressionCache
 {
     const IMPRESSIONS_QUEUE_KEY = "SPLITIO.impressions";
     const IMPRESSION_KEY_DEFAULT_TTL = 3600;
 
-    public function logImpressions($impressions, $metadata)
+    public function logImpressions($impressions, QueueMetadataMessage $metadata)
     {
         $toStore = array_map(
             function ($imp) use ($metadata) {
                 return json_encode(array(
-                    "m" => array(
-                        "s" => $metadata['sdkVersion'],
-                        "i" => $metadata['machineIp'],
-                        "n" => $metadata['machineName'],
-                    ),
+                    'm' => $metadata->toArray(),
                     "i" => array(
                         "k" => $imp->getId(),
                         "b" => $imp->getBucketingKey(),

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -39,7 +39,8 @@ class Client implements ClientInterface
         if (isset($options['impressionListener'])) {
             $this->impressionListener = new \SplitIO\Sdk\ImpressionListenerWrapper($options['impressionListener']);
         }
-        $this->IPAddressesEnabled = isset($options['IPAddressesEnabled']) ? $options['IPAddressesEnabled'] : true;
+        $IPAddressesEnabled = isset($options['IPAddressesEnabled']) ? $options['IPAddressesEnabled'] : true;
+        $this->queueMetadata = new QueueMetadataMessage($IPAddressesEnabled);
     }
 
     /**
@@ -307,8 +308,7 @@ class Client implements ClientInterface
     private function registerData($impressions, $attributes, $metricName, $latency = null)
     {
         try {
-            $queueMetadata = new QueueMetadataMessage($this->IPAddressesEnabled);
-            TreatmentImpression::log($impressions, $queueMetadata);
+            TreatmentImpression::log($impressions, $this->queueMetadata);
             if (isset($this->impressionListener)) {
                 $this->impressionListener->sendDataToClient($impressions, $attributes);
             }
@@ -544,8 +544,7 @@ class Client implements ClientInterface
 
         try {
             $eventDTO = new EventDTO($key, $trafficType, $eventType, $value, $properties);
-            $queueMetadata = new QueueMetadataMessage($this->IPAddressesEnabled);
-            $eventQueueMessage = new EventQueueMessage($queueMetadata, $eventDTO);
+            $eventQueueMessage = new EventQueueMessage($this->queueMetadata, $eventDTO);
             return EventsCache::addEvent($eventQueueMessage);
         } catch (\Exception $exception) {
             // @codeCoverageIgnoreStart

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -39,8 +39,9 @@ class Client implements ClientInterface
         if (isset($options['impressionListener'])) {
             $this->impressionListener = new \SplitIO\Sdk\ImpressionListenerWrapper($options['impressionListener']);
         }
-        $IPAddressesEnabled = isset($options['IPAddressesEnabled']) ? $options['IPAddressesEnabled'] : true;
-        $this->queueMetadata = new QueueMetadataMessage($IPAddressesEnabled);
+        $this->queueMetadata = new QueueMetadataMessage(
+            isset($options['IPAddressesEnabled']) ? $options['IPAddressesEnabled'] : true
+        );
     }
 
     /**

--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -20,7 +20,6 @@ class Client implements ClientInterface
 
     private $evaluator = null;
     private $impressionListener = null;
-    private $IPAddressesEnabled = true;
 
     /**
      * Flag to get Impression's labels feature enabled

--- a/src/SplitIO/Sdk/Events/EventQueueMessage.php
+++ b/src/SplitIO/Sdk/Events/EventQueueMessage.php
@@ -1,6 +1,8 @@
 <?php
 namespace SplitIO\Sdk\Events;
 
+use SplitIO\Sdk\QueueMetadataMessage;
+
 class EventQueueMessage
 {
     /**
@@ -18,7 +20,7 @@ class EventQueueMessage
      * @param $metadata
      * @param $event
      */
-    public function __construct(EventQueueMetadataMessage $metadata, EventDTO $event)
+    public function __construct(QueueMetadataMessage $metadata, EventDTO $event)
     {
         $this->metadata = $metadata;
         $this->event = $event;
@@ -26,7 +28,7 @@ class EventQueueMessage
 
 
     /**
-     * @return EventQueueMetadataMessage
+     * @return QueueMetadataMessage
      */
     public function getMetadata()
     {
@@ -36,7 +38,7 @@ class EventQueueMessage
     /**
      * @param mixed $metadata
      */
-    public function setMetadata(EventQueueMetadataMessage $metadata)
+    public function setMetadata(QueueMetadataMessage $metadata)
     {
         $this->metadata = $metadata;
     }

--- a/src/SplitIO/Sdk/QueueMetadataMessage.php
+++ b/src/SplitIO/Sdk/QueueMetadataMessage.php
@@ -15,8 +15,8 @@ class QueueMetadataMessage
     public function __construct($IPAddressesEnabled = true)
     {
         $this->sdkVersion = 'php-' . \SplitIO\version();
-        $this->machineIP = 'na';
-        $this->machineName = 'na';
+        $this->machineIP = 'NA';
+        $this->machineName = 'NA';
         if ($IPAddressesEnabled) {
             $this->machineIP = \SplitIO\getHostIpAddress();
             if ($this->machineIP != 'unknown') {

--- a/src/SplitIO/Sdk/QueueMetadataMessage.php
+++ b/src/SplitIO/Sdk/QueueMetadataMessage.php
@@ -1,7 +1,7 @@
 <?php
-namespace SplitIO\Sdk\Events;
+namespace SplitIO\Sdk;
 
-class EventQueueMetadataMessage
+class QueueMetadataMessage
 {
     private $sdkVersion;
 
@@ -10,15 +10,22 @@ class EventQueueMetadataMessage
     private $machineName;
 
     /**
-     * EventQueueMetadataMessage constructor.
+     * QueueMetadataMessage constructor.
      */
-    public function __construct()
+    public function __construct($IPAddressesEnabled = true)
     {
         $this->sdkVersion = 'php-' . \SplitIO\version();
-        $this->machineIP = \SplitIO\getHostIpAddress();
-        $this->machineName = 'unknown';
+        $this->machineIP = 'na';
+        $this->machineName = 'na';
+        if ($IPAddressesEnabled) {
+            $this->machineIP = \SplitIO\getHostIpAddress();
+            if ($this->machineIP != 'unknown') {
+                $this->machineName = 'ip-' . str_replace('.', '-', $this->machineIP);
+            } else {
+                $this->machineName = 'unknown';
+            }
+        }
     }
-
 
     /**
      * @return mixed

--- a/src/SplitIO/TreatmentImpression.php
+++ b/src/SplitIO/TreatmentImpression.php
@@ -17,7 +17,7 @@ class TreatmentImpression
         try {
             Di::getLogger()->debug($impressions);
             if (is_null($impressions) || (is_array($impressions) && 0 == count($impressions))) {
-                return;
+                return null;
             }
             $impressionCache = new ImpressionCache();
             $toStore = (is_array($impressions)) ? $impressions : array($impressions);

--- a/src/SplitIO/TreatmentImpression.php
+++ b/src/SplitIO/TreatmentImpression.php
@@ -4,6 +4,7 @@ namespace SplitIO;
 use SplitIO\Component\Cache\ImpressionCache;
 use SplitIO\Sdk\Impressions\Impression;
 use SplitIO\Component\Common\Di;
+use SplitIO\Sdk\QueueMetadataMessage;
 
 class TreatmentImpression
 {
@@ -11,7 +12,7 @@ class TreatmentImpression
      * @param \SplitIO\Sdk\Impressions\Impression $impressions
      * @return bool
      */
-    public static function log($impressions)
+    public static function log($impressions, QueueMetadataMessage $metadata)
     {
         try {
             Di::getLogger()->debug($impressions);
@@ -22,11 +23,7 @@ class TreatmentImpression
             $toStore = (is_array($impressions)) ? $impressions : array($impressions);
             return $impressionCache->logImpressions(
                 $toStore,
-                array(
-                    'sdkVersion' => 'php-' . \SplitIO\version(),
-                    'machineIp' => \SplitIO\getHostIpAddress(),
-                    'machineName' => null, // TODO
-                )
+                $metadata
             );
         } catch (\Exception $e) {
             Di::getLogger()->warning('Unable to write impression back to redis.');

--- a/src/SplitIO/Version.php
+++ b/src/SplitIO/Version.php
@@ -3,5 +3,5 @@ namespace SplitIO;
 
 class Version
 {
-    const CURRENT = '6.2.2';
+    const CURRENT = '6.2.3-rc1';
 }

--- a/tests/Suite/Sdk/ImpressionsTest.php
+++ b/tests/Suite/Sdk/ImpressionsTest.php
@@ -109,8 +109,8 @@ class ImpressionsTest extends \PHPUnit_Framework_TestCase
         $decoded = json_decode($imp, true);
 
         $this->assertEquals($decoded['m']['s'], 'php-'.\Splitio\version());
-        $this->assertEquals($decoded['m']['i'], 'na');
-        $this->assertEquals($decoded['m']['n'], 'na');
+        $this->assertEquals($decoded['m']['i'], 'NA');
+        $this->assertEquals($decoded['m']['n'], 'NA');
         $this->assertEquals($decoded['i']['k'], 'someMatchingKey');
         $this->assertEquals($decoded['i']['b'], 'someBucketingKey');
         $this->assertEquals($decoded['i']['f'], 'someFeature');

--- a/tests/Suite/Sdk/SdkClientTest.php
+++ b/tests/Suite/Sdk/SdkClientTest.php
@@ -575,7 +575,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         //Check impressions generated
         $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
-        $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on', 'na', 'na');
+        $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on', 'NA', 'NA');
     }
 
     public function testGetTreatmentsWithRepeteadedFeatures()

--- a/tests/Suite/Sdk/SdkClientTest.php
+++ b/tests/Suite/Sdk/SdkClientTest.php
@@ -209,13 +209,22 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    private function validateLastImpression($redisClient, $feature, $key, $treatment)
-    {
+    private function validateLastImpression(
+        $redisClient,
+        $feature,
+        $key,
+        $treatment,
+        $machineName = 'unknown',
+        $machineIP = 'unknown'
+    ) {
         $raw = $redisClient->rpop(ImpressionCache::IMPRESSIONS_QUEUE_KEY);
         $parsed = json_decode($raw, true);
+        echo "parsed " . json_encode($parsed) . "\n";
         $this->assertEquals($parsed['i']['f'], $feature);
         $this->assertEquals($parsed['i']['k'], $key);
         $this->assertEquals($parsed['i']['t'], $treatment);
+        $this->assertEquals($parsed['m']['i'], $machineIP);
+        $this->assertEquals($parsed['m']['n'], $machineName);
     }
 
     public function testClient()
@@ -544,7 +553,8 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         $sdkConfig = array(
             'log' => array('adapter' => 'stdout'),
-            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options),
+            'IPAddressesEnabled' => false
         );
 
         //Initializing the SDK instance.
@@ -565,7 +575,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         //Check impressions generated
         $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
-        $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
+        $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on', 'na', 'na');
     }
 
     public function testGetTreatmentsWithRepeteadedFeatures()
@@ -580,7 +590,8 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         $sdkConfig = array(
             'log' => array('adapter' => 'stdout'),
-            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options)
+            'cache' => array('adapter' => 'predis', 'parameters' => $parameters, 'options' => $options),
+            'ipAddress' => '1.2.3.4'
         );
 
         //Initializing the SDK instance.
@@ -602,12 +613,13 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
         // Check impressions
         $redisClient = ReflectiveTools::clientFromCachePool(Di::getCache());
-        $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on');
+        $this->validateLastImpression($redisClient, 'sample_feature', 'user1', 'on', 'ip-1-2-3-4', '1.2.3.4');
     }
 
     public function testGetTreatmentsWithRepeteadedAndNullFeatures()
     {
         Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set('ipAddress', null); // unset ipaddress from previous test
 
         //Testing version string
         $this->assertTrue(is_string(\SplitIO\version()));
@@ -680,5 +692,4 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
         $client = new Client();
         $client->getTreatments('key1', array('split1', 'split2', 'split3'));
     }
-
 }

--- a/tests/Suite/Sdk/SdkReadOnlyTest.php
+++ b/tests/Suite/Sdk/SdkReadOnlyTest.php
@@ -9,6 +9,7 @@ use SplitIO\Test\Suite\Redis\PRedisReadOnlyMock;
 use SplitIO\TreatmentImpression;
 use SplitIO\Grammar\Condition\Partition\TreatmentEnum;
 use SplitIO\Sdk\Impressions\Impression;
+use SplitIO\Sdk\QueueMetadataMessage;
 
 class SdkReadOnlyTest extends \PHPUnit_Framework_TestCase
 {
@@ -126,6 +127,6 @@ class SdkReadOnlyTest extends \PHPUnit_Framework_TestCase
             'something'
         );
 
-        TreatmentImpression::log($impression);
+        TreatmentImpression::log($impression, new QueueMetadataMessage());
     }
 }


### PR DESCRIPTION
# PHP SDK

## What did you accomplish?
- Added flag `IPAddressesEnabled` to enable/disable sending machineName and machineIP to Split Servers.

## How do we test the changes introduced in this PR?

## Extra Notes
