### PR TITLE
Add missing methods to ClientInterface.php

### DIFF
--- a/src/SplitIO/Sdk/Client.php
+++ b/src/SplitIO/Sdk/Client.php
@@ -168,37 +168,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * Returns the treatment to show this id for this feature.
-     * The set of treatments for a feature can be configured
-     * on the Split web console.
-     * This method returns the string 'control' if:
-     * <ol>
-     *     <li>Any of the parameters were null</li>
-     *     <li>There was an exception</li>
-     *     <li>The SDK does not know this feature</li>
-     *     <li>The feature was deleted through the web console.</li>
-     * </ol>
-     * 'control' is a reserved treatment, to highlight these
-     * exceptional circumstances.
-     *
-     * <p>
-     * The sdk returns the default treatment of this feature if:
-     * <ol>
-     *     <li>The feature was killed</li>
-     *     <li>The id did not match any of the conditions in the
-     * feature roll-out plan</li>
-     * </ol>
-     * The default treatment of a feature is set on the Split web
-     * console.
-     *
-     * <p>
-     * This method does not throw any exceptions.
-     * It also never  returns null.
-     *
-     * @param $key
-     * @param $featureName
-     * @param $attributes
-     * @return string
+     * @inheritdoc
      */
     public function getTreatment($key, $featureName, array $attributes = null)
     {
@@ -218,42 +188,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * Returns an object with the treatment to show this id for this feature
-     * and the config provided.
-     * The set of treatments and config for a feature can be configured
-     * on the Split web console.
-     * This method returns the string 'control' if:
-     * <ol>
-     *     <li>Any of the parameters were null</li>
-     *     <li>There was an exception</li>
-     *     <li>The SDK does not know this feature</li>
-     *     <li>The feature was deleted through the web console.</li>
-     * </ol>
-     * 'control' is a reserved treatment, to highlight these
-     * exceptional circumstances.
-     *
-     * <p>
-     * The sdk returns the default treatment of this feature if:
-     * <ol>
-     *     <li>The feature was killed</li>
-     *     <li>The id did not match any of the conditions in the
-     * feature roll-out plan</li>
-     * </ol>
-     * The default treatment of a feature is set on the Split web
-     * console.
-     *
-     * <p>
-     * This method does not throw any exceptions.
-     * It also never returns null.
-     *
-     * This method returns null configuration if:
-     * <ol>
-     *     <li>config was not set up</li>
-     * </ol>
-     * @param $key
-     * @param $featureName
-     * @param $attributes
-     * @return string
+     * @inheritdoc
      */
     public function getTreatmentWithConfig($key, $featureName, array $attributes = null)
     {
@@ -388,35 +323,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * Returns an associative array which each key will be
-     * the treatment result for each feature passed as parameter.
-     * The set of treatments for a feature can be configured
-     * on the Split web console.
-     * This method returns the string 'control' if:
-     * <ol>
-     *     <li>featureNames is invalid/li>
-     * </ol>
-     * 'control' is a reserved treatment, to highlight these
-     * exceptional circumstances.
-     *
-     * <p>
-     * The sdk returns the default treatment of this feature if:
-     * <ol>
-     *     <li>The feature was killed</li>
-     *     <li>The id did not match any of the conditions in the
-     * feature roll-out plan</li>
-     * </ol>
-     * The default treatment of a feature is set on the Split web
-     * console.
-     *
-     * <p>
-     * This method does not throw any exceptions.
-     * It also never returns null.
-     *
-     * @param $key
-     * @param $featureNames
-     * @param $attributes
-     * @return array|control
+     * @inheritdoc
      */
     public function getTreatments($key, $featureNames, array $attributes = null)
     {
@@ -434,44 +341,14 @@ class Client implements ClientInterface
                 )
             );
         } catch (\Exception $e) {
-            SplitApp::logger()->critical('getTreatmens method is throwing exceptions');
+            SplitApp::logger()->critical('getTreatments method is throwing exceptions');
             $splitNames = InputValidator::validateFeatureNames($featureNames, 'getTreatments');
             return is_null($splitNames) ? array() : array_fill_keys($splitNames, TreatmentEnum::CONTROL);
         }
     }
 
     /**
-     * Returns an associative array which each key will be
-     * the treatment result and the config for each
-     * feature passed as parameter.
-     * The set of treatments for a feature can be configured
-     * on the Split web console and the config for
-     * that treatment.
-     * This method returns the string 'control' if:
-     * <ol>
-     *     <li>featureNames is invalid/li>
-     * </ol>
-     * 'control' is a reserved treatment, to highlight these
-     * exceptional circumstances.
-     *
-     * <p>
-     * The sdk returns the default treatment of this feature if:
-     * <ol>
-     *     <li>The feature was killed</li>
-     *     <li>The id did not match any of the conditions in the
-     * feature roll-out plan</li>
-     * </ol>
-     * The default treatment of a feature is set on the Split web
-     * console.
-     *
-     * <p>
-     * This method does not throw any exceptions.
-     * It also never returns null.
-     *
-     * @param $key
-     * @param $featureNames
-     * @param $attributes
-     * @return array|control
+     * @inheritdoc
      */
     public function getTreatmentsWithConfig($key, $featureNames, array $attributes = null)
     {
@@ -492,18 +369,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * A short-hand for
-     * <pre>
-     *     (getTreatment(key, feature) == treatment) ? true : false;
-     * </pre>
-     *
-     * This method never throws exceptions.
-     * Instead of throwing  exceptions, it returns false.
-     *
-     * @param $key
-     * @param $featureName
-     * @param $treatment
-     * @return bool
+     * @inheritdoc
      */
     public function isTreatment($key, $featureName, $treatment)
     {

--- a/src/SplitIO/Sdk/ClientInterface.php
+++ b/src/SplitIO/Sdk/ClientInterface.php
@@ -39,6 +39,114 @@ interface ClientInterface
     public function getTreatment($key, $featureName, array $attributes = null);
 
     /**
+     * Returns an object with the treatment to show this id for this feature
+     * and the config provided.
+     * The set of treatments and config for a feature can be configured
+     * on the Split web console.
+     * This method returns the string 'control' if:
+     * <ol>
+     *     <li>Any of the parameters were null</li>
+     *     <li>There was an exception</li>
+     *     <li>The SDK does not know this feature</li>
+     *     <li>The feature was deleted through the web console.</li>
+     * </ol>
+     * 'control' is a reserved treatment, to highlight these
+     * exceptional circumstances.
+     *
+     * <p>
+     * The sdk returns the default treatment of this feature if:
+     * <ol>
+     *     <li>The feature was killed</li>
+     *     <li>The id did not match any of the conditions in the
+     * feature roll-out plan</li>
+     * </ol>
+     * The default treatment of a feature is set on the Split web
+     * console.
+     *
+     * <p>
+     * This method does not throw any exceptions.
+     * It also never returns null.
+     *
+     * This method returns null configuration if:
+     * <ol>
+     *     <li>config was not set up</li>
+     * </ol>
+     * @param $key
+     * @param $featureName
+     * @param $attributes
+     * @return string
+     */
+    public function getTreatmentWithConfig($key, $featureName, array $attributes = null);
+
+    /**
+     * Returns an associative array which each key will be
+     * the treatment result for each feature passed as parameter.
+     * The set of treatments for a feature can be configured
+     * on the Split web console.
+     * This method returns the string 'control' if:
+     * <ol>
+     *     <li>featureNames is invalid/li>
+     * </ol>
+     * 'control' is a reserved treatment, to highlight these
+     * exceptional circumstances.
+     *
+     * <p>
+     * The sdk returns the default treatment of this feature if:
+     * <ol>
+     *     <li>The feature was killed</li>
+     *     <li>The id did not match any of the conditions in the
+     * feature roll-out plan</li>
+     * </ol>
+     * The default treatment of a feature is set on the Split web
+     * console.
+     *
+     * <p>
+     * This method does not throw any exceptions.
+     * It also never returns null.
+     *
+     * @param $key
+     * @param $featureNames
+     * @param $attributes
+     * @return array
+     */
+    public function getTreatments($key, $featureNames, array $attributes = null);
+
+    /**
+     * Returns an associative array which each key will be
+     * the treatment result and the config for each
+     * feature passed as parameter.
+     * The set of treatments for a feature can be configured
+     * on the Split web console and the config for
+     * that treatment.
+     * This method returns the string 'control' if:
+     * <ol>
+     *     <li>featureNames is invalid/li>
+     * </ol>
+     * 'control' is a reserved treatment, to highlight these
+     * exceptional circumstances.
+     *
+     * <p>
+     * The sdk returns the default treatment of this feature if:
+     * <ol>
+     *     <li>The feature was killed</li>
+     *     <li>The id did not match any of the conditions in the
+     * feature roll-out plan</li>
+     * </ol>
+     * The default treatment of a feature is set on the Split web
+     * console.
+     *
+     * <p>
+     * This method does not throw any exceptions.
+     * It also never returns null.
+     *
+     * @param $key
+     * @param $featureNames
+     * @param $attributes
+     * @return array
+     */
+    public function getTreatmentsWithConfig($key, $featureNames, array $attributes = null);
+
+    /**
      * A short-hand for
      * <pre>
      *     (getTreatment(key, feature) == treatment) ? true : false;

--- a/src/SplitIO/Sdk/LocalhostClient.php
+++ b/src/SplitIO/Sdk/LocalhostClient.php
@@ -134,36 +134,7 @@ class LocalhostClient implements ClientInterface
     }
 
     /**
-     * Returns the treatment to show this id for this feature.
-     * The set of treatments for a feature can be configured
-     * on the Split web console.
-     * This method returns the string 'control' if:
-     * <ol>
-     *     <li>Any of the parameters were null</li>
-     *     <li>There was an exception</li>
-     *     <li>The SDK does not know this feature</li>
-     *     <li>The feature was deleted through the web console.</li>
-     * </ol>
-     * 'control' is a reserved treatment, to highlight these
-     * exceptional circumstances.
-     *
-     * <p>
-     * The sdk returns the default treatment of this feature if:
-     * <ol>
-     *     <li>The feature was killed</li>
-     *     <li>The id did not match any of the conditions in the
-     * feature roll-out plan</li>
-     * </ol>
-     * The default treatment of a feature is set on the Split web
-     * console.
-     *
-     * <p>
-     * This method does not throw any exceptions.
-     * It also never  returns null.
-     *
-     * @param $key
-     * @param $featureName
-     * @return string
+     * @inheritdoc
      */
     public function getTreatment($key, $featureName, array $attributes = null)
     {
@@ -183,6 +154,9 @@ class LocalhostClient implements ClientInterface
         return TreatmentEnum::CONTROL;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getTreatmentWithConfig($key, $featureName, array $attributes = null)
     {
         $treatmentResult = array(
@@ -212,7 +186,10 @@ class LocalhostClient implements ClientInterface
         return $treatmentResult;
     }
 
-    public function getTreatments($key, $featureNames, $attributes = null)
+    /**
+     * @inheritdoc
+     */
+    public function getTreatments($key, $featureNames, array $attributes = null)
     {
         $splitNames = InputValidator::validateFeatureNames($featureNames, "getTreatments");
         if (is_null($splitNames)) {
@@ -233,7 +210,10 @@ class LocalhostClient implements ClientInterface
         return $result;
     }
 
-    public function getTreatmentsWithConfig($key, $featureNames, $attributes = null)
+    /**
+     * @inheritdoc
+     */
+    public function getTreatmentsWithConfig($key, $featureNames, array $attributes = null)
     {
         $splitNames = InputValidator::validateFeatureNames($featureNames, "getTreatmentsWithConfig");
         if (is_null($splitNames)) {
@@ -255,13 +235,7 @@ class LocalhostClient implements ClientInterface
     }
 
     /**
-     * This method never throws exceptions.
-     * Instead of throwing  exceptions, it returns false.
-     *
-     * @param $key
-     * @param $featureName
-     * @param $treatment
-     * @return bool
+     * @inheritdoc
      */
     public function isTreatment($key, $featureName, $treatment)
     {


### PR DESCRIPTION
# PHP SDK

## What did you accomplish?
* Update `ClientInterface` to add missing public methods that were available on `Client` and `LocalhostClient`

## How do we test the changes introduced in this PR?
* Existing unit tests and regression *should* be sufficient.
* Consumers of the library should now be able to freely use `ClientInterface` in place of the concrete implementation's FQCN.

## Extra Notes
n/a