### PR TITLE
Trim cached string before decoding

### DIFF
--- a/src/SplitIO/Component/Memory/SharedMemory.php
+++ b/src/SplitIO/Component/Memory/SharedMemory.php
@@ -87,7 +87,10 @@ class SharedMemory
             throw new ReadSharedMemoryException("The shared memory block could not be read");
         }
 
-        $data = json_decode($cached_string, true);
+        $data = json_decode(
+            trim($cached_string),
+            true
+        );
 
         if ((isset($data['expiration']) && time() > $data['expiration']) || !isset($data['expiration'])) {
             shmop_delete($shm_id);

--- a/src/SplitIO/Component/Memory/SharedMemory.php
+++ b/src/SplitIO/Component/Memory/SharedMemory.php
@@ -37,7 +37,7 @@ class SharedMemory
 
         $expiration = time() + $expiration;
 
-        $data = json_encode(array('expiration' => $expiration, 'value' => serialize($value)));
+        $data = json_encode(array('expiration' => $expiration, 'value' => serialize($value))) . "\0";
 
         @$shm_id = shmop_open($key, "c", $mode, $size);
 
@@ -87,8 +87,9 @@ class SharedMemory
             throw new ReadSharedMemoryException("The shared memory block could not be read");
         }
 
+        $null_pos = strpos($cached_string, "\0");
         $data = json_decode(
-            trim($cached_string),
+            substr($cached_string, 0, $null_pos),
             true
         );
 

--- a/tests/Suite/Component/Memory/SharedMemoryTest.php
+++ b/tests/Suite/Component/Memory/SharedMemoryTest.php
@@ -1,0 +1,38 @@
+<?php
+namespace SplitIO\Test\Suite\Component\Memory;
+
+use SplitIO\Component\Memory\SharedMemory as Sut;
+
+class SharedMemoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testWrite()
+    {
+        if (!extension_loaded('shmop')) {
+            $this->markTestSkipped(
+                'The shmop extension is not available.'
+            );
+        }
+
+        $key = 1234;
+        $value = 'bar';
+
+        Sut::write($key, $value);
+
+        return [$key, $value];
+    }
+
+    /**
+     * @depends testWrite
+     */
+    public function testRead(array $tuple)
+    {
+        list($key, $expected) = $tuple;
+
+        $given = Sut::read($key);
+        $this->assertEquals($expected, $given );
+    }
+
+}

--- a/tests/Suite/Component/Memory/SharedMemoryTest.php
+++ b/tests/Suite/Component/Memory/SharedMemoryTest.php
@@ -32,7 +32,32 @@ class SharedMemoryTest extends \PHPUnit_Framework_TestCase
         list($key, $expected) = $tuple;
 
         $given = Sut::read($key);
-        $this->assertEquals($expected, $given );
+        $this->assertEquals($expected, $given);
+    }
+
+    public function overwriteProvider()
+    {
+        return [
+            'longer to shorter' => [4321, str_repeat('a', 50), 'b'],
+            'shorter to longer' => [5555, 'c', 'ddddd'],
+        ];
+    }
+
+    /**
+     * @dataProvider overwriteProvider
+     */
+    public function testOverwrite($key, $original_value, $updated_value)
+    {
+        if (!extension_loaded('shmop')) {
+            $this->markTestSkipped(
+                'The shmop extension is not available.'
+            );
+        }
+
+        Sut::write($key, $original_value);
+        Sut::write($key, $updated_value);
+        $given = Sut::read($key);
+        $this->assertEquals($updated_value, $given);
     }
 
 }


### PR DESCRIPTION
The `$cached_string` pulled out of the shared memory has trailing chars
that result in the string not being able to be decoded using
`json_decode`. This will never work unless the `$size` is the exact size
of the cached string.  Using `trim` fixes the issue.

# PHP SDK

## What did you accomplish?

Fixed a bug in the shared memory where the shared memory only works if the size is exactly the same.

## How do we test the changes introduced in this PR?

Remove my change to the `src/` directory and run the tests, my new test should fail. For further testing, use a large `size` in your memory config and try to use the cache with something small.

## Extra Notes

The integration tests did not pass for me out of the box. As a result, I only ensured that my new test works. 

This is related to issue #148. 