### PR TITLE
add method to create singleton factories

### DIFF
--- a/src/SplitIO/Component/Common/Di.php
+++ b/src/SplitIO/Component/Common/Di.php
@@ -22,7 +22,7 @@ class Di
 
     const KEY_EVALUATOR = 'EVALUATOR';
 
-    const KEY_FACTORY_TRACKER = 'FACTORY-TRACKER';
+    const KEY_FACTORY = 'FACTORY';
 
     /**
      * @var Singleton The reference to *Singleton* instance of this class

--- a/tests/Suite/Attributes/SdkAttributesTest.php
+++ b/tests/Suite/Attributes/SdkAttributesTest.php
@@ -44,7 +44,7 @@ class SdkAttributesTest extends \PHPUnit_Framework_TestCase
 
     public function testClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
 
         //Testing version string
         $this->assertTrue(is_string(\SplitIO\version()));

--- a/tests/Suite/InputValidation/GetTreatmentValidationTest.php
+++ b/tests/Suite/InputValidation/GetTreatmentValidationTest.php
@@ -8,7 +8,7 @@ class GetTreatmentValidationTest extends \PHPUnit_Framework_TestCase
 {
     private function getFactoryClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 

--- a/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
+++ b/tests/Suite/InputValidation/GetTreatmentsValidationTest.php
@@ -8,7 +8,7 @@ class GetTreatmentsValidationTest extends \PHPUnit_Framework_TestCase
 {
     private function getFactoryClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 

--- a/tests/Suite/InputValidation/ManagerValidationTest.php
+++ b/tests/Suite/InputValidation/ManagerValidationTest.php
@@ -7,7 +7,7 @@ class ManagerValidationTest extends \PHPUnit_Framework_TestCase
 {
     private function getFactoryClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 

--- a/tests/Suite/InputValidation/TrackValidationTest.php
+++ b/tests/Suite/InputValidation/TrackValidationTest.php
@@ -8,7 +8,7 @@ class TrackValidationTest extends \PHPUnit_Framework_TestCase
 {
     private function getFactoryClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 

--- a/tests/Suite/Matchers/MatchersTest.php
+++ b/tests/Suite/Matchers/MatchersTest.php
@@ -14,7 +14,7 @@ class MatcherTest extends \PHPUnit_Framework_TestCase
 {
     private function setupSplitApp()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array(
             'scheme' => 'redis',
             'host' => "localhost",

--- a/tests/Suite/Sdk/ImpressionWrapperTest.php
+++ b/tests/Suite/Sdk/ImpressionWrapperTest.php
@@ -56,7 +56,7 @@ class ImpressionListenerTest extends \PHPUnit_Framework_TestCase
 
     private function getFactoryClient($sdkConfig)
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 

--- a/tests/Suite/Sdk/ImpressionsTest.php
+++ b/tests/Suite/Sdk/ImpressionsTest.php
@@ -12,7 +12,7 @@ class ImpressionsTest extends \PHPUnit_Framework_TestCase
 {
     public function testImpressionsAreAdded()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 
@@ -61,7 +61,7 @@ class ImpressionsTest extends \PHPUnit_Framework_TestCase
 
     public function testExpirationOnlyOccursOnce()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
 

--- a/tests/Suite/Sdk/SdkClientTest.php
+++ b/tests/Suite/Sdk/SdkClientTest.php
@@ -54,7 +54,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testLocalClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $options['splitFile'] = dirname(dirname(__DIR__)).'/files/.splits';
         $splitFactory = \SplitIO\Sdk::factory('localhost', $options);
         $splitSdk = $splitFactory->client();
@@ -71,7 +71,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testLocalClientYAML()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $options['splitFile'] = dirname(dirname(__DIR__)).'/files/splits.yml';
         $splitFactory = \SplitIO\Sdk::factory('localhost', $options);
         $splitSdk = $splitFactory->client();
@@ -229,7 +229,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         //Testing version string
         $this->assertTrue(is_string(\SplitIO\version()));
 
@@ -459,7 +459,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCustomLog()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         // create a log channel
         $log = new Logger('SplitIO');
         $log->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, Logger::INFO));
@@ -490,7 +490,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidCacheAdapter()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $this->setExpectedException('\SplitIO\Exception\Exception');
 
         $sdkConfig = array(
@@ -504,7 +504,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testCacheExceptionReturnsControl()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         $log = new Logger('SplitIO');
         $log->pushHandler(new ErrorLogHandler(ErrorLogHandler::OPERATING_SYSTEM, Logger::INFO));
 
@@ -544,7 +544,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTreatmentsWithDistinctFeatures()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         //Testing version string
         $this->assertTrue(is_string(\SplitIO\version()));
 
@@ -580,7 +580,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTreatmentsWithRepeteadedFeatures()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
 
         //Testing version string
         $this->assertTrue(is_string(\SplitIO\version()));
@@ -618,7 +618,7 @@ class SdkClientTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTreatmentsWithRepeteadedAndNullFeatures()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
         Di::set('ipAddress', null); // unset ipaddress from previous test
 
         //Testing version string

--- a/tests/Suite/Sdk/SdkReadOnlyTest.php
+++ b/tests/Suite/Sdk/SdkReadOnlyTest.php
@@ -28,7 +28,7 @@ class SdkReadOnlyTest extends \PHPUnit_Framework_TestCase
 
     public function testClient()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
 
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();
@@ -74,7 +74,7 @@ class SdkReadOnlyTest extends \PHPUnit_Framework_TestCase
 
     public function testException()
     {
-        Di::set(Di::KEY_FACTORY_TRACKER, false);
+        Di::set(Di::KEY_FACTORY, false);
 
         $parameters = array('scheme' => 'redis', 'host' => REDIS_HOST, 'port' => REDIS_PORT, 'timeout' => 881);
         $options = array();


### PR DESCRIPTION
# PHP SDK

## What did you accomplish?

Implemented a new way of instantiating factories. The problems I've faced are described in #150 

## How do we test the changes introduced in this PR?

The unit test at FactoryTrackerTest::testMultipleSingletonClientInstantiation should be self-explanatory. But here goes a simple snippet:

```php
<?php

require __DIR__ . '/vendor/autoload.php';

$sdkConfig = array('cache' => array('adapter' => 'predis'));

$splitFactory = \SplitIO\Sdk::singleton('SDK_API_KEY', $sdkConfig);
var_dump($splitFactory); // this hsould not be null

$splitFactory2 = \SplitIO\Sdk::singleton('SDK_API_KEY', $sdkConfig);
var_dump($splitFactory2); // this should not be null

var_dump($splitFactory === $splitFactory2); // this should be true

$splitClient = $splitFactory->client();
$treatment = $splitClient->getTreatment('CUSTOMER_ID', 'SPLIT_NAME');

if ($treatment === 'on') {
    // Feature is enabled for this user!
} elseif ($treatment === 'off') {
    // Feature is disabled for this user!
} else {
    // Unable to perform evaluation.
}
```