### PR TITLE
Fix PHP 8.0 compatibility

### DIFF
--- a/src/SplitIO/Component/Common/Di.php
+++ b/src/SplitIO/Component/Common/Di.php
@@ -72,7 +72,7 @@ class Di
      *
      * @return void
      */
-    private function __wakeup()
+    public function __wakeup()
     {
     }
 

--- a/src/SplitIO/Component/Common/Di.php
+++ b/src/SplitIO/Component/Common/Di.php
@@ -62,7 +62,7 @@ class Di
      *
      * @return void
      */
-    private function __clone()
+    public function __clone()
     {
     }
 


### PR DESCRIPTION
PHP official documentation explicitly states 
> All magic methods, with the exception of __construct(), __destruct(), and __clone(), must be declared as public.

https://www.php.net/manual/en/language.oop5.magic.php

This issue makes our builds fail.

# PHP SDK

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes
