### PR TITLE
Exclude tests folder from Git archive / composer archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.github export-ignore
+tests export-ignore


### PR DESCRIPTION
# PHP SDK

## What did you accomplish?
The current distribution, as built with git archive and composer when a release is tagged, includes test files. This presently adds 14mb to production distributions that don't need to be present in production builds.

## How do we test the changes introduced in this PR?
Either #1, or #2 and #3.

1. Tag an alpha release version of the composer package, and note that the zip archive generated should exclude the tests/ and .github/ folders.
1. Run the following commands on the `master` branch, noting that tests are included with the archive
    ```
    git archive master -o test.tar .
    tar -tvf test.tar 'tests' 
    ```
1. Run the following commands on this branch, noting that no results are found.
    ```
    git archive exclude-tests-from-composer-archive -o test.tar .
    tar -tvf test.tar 'tests' 
    ```

## Extra Notes
* In a reasonably sized production application, this change would account for a 6% reduction in size of vendor packages.
* https://git-scm.com/docs/gitattributes
* https://stackoverflow.com/questions/17049313/how-to-ignore-directories-with-composer
* https://medium.com/@pavlakis/sharing-with-composer-and-gitattributes-4423f5c4967f
