### PR TITLE
Allow symfony/yaml v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php": ">=7.3",
     "psr/log": "1 - 3",
     "predis/predis": "^2.0",
-    "symfony/yaml": "^5.3|^6.0"
+    "symfony/yaml": "^5.3|^6.0|^7.0"
   },
 
   "require-dev": {


### PR DESCRIPTION
https://github.com/symfony/yaml/blob/7.0/CHANGELOG.md#70

Breaking change limited to how php constants can be used.

# PHP SDK

## What did you accomplish?

## How do we test the changes introduced in this PR?

## Extra Notes
