### PR TITLE
fix: incorrect arg count local mode

### DIFF
--- a/src/SplitIO/Sdk/Manager/LocalhostSplitManager.php
+++ b/src/SplitIO/Sdk/Manager/LocalhostSplitManager.php
@@ -66,7 +66,9 @@ class LocalhostSplitManager implements SplitManagerInterface
                     false,
                     $this->splits[$featureFlagName]["treatments"],
                     0,
-                    $configs
+                    $configs,
+                    null,
+                    array()
                 );
             }
         }

--- a/tests/Suite/Sdk/LocalhostSplitManagerTest.php
+++ b/tests/Suite/Sdk/LocalhostSplitManagerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SplitIO\Test\Suite\Sdk;
+
+use SplitIO\Sdk\Manager\LocalhostSplitManager;
+
+class LocalhostSplitManagerTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Regression test that SplitView constructor is called with correct number of arguments
+     *
+     * @see https://github.com/splitio/php-client/issues/240
+     */
+    public function testSplitViewConstructorArgumentCount()
+    {
+        $manager = new LocalhostSplitManager([]);
+
+        // This should not throw any "too few arguments" or "too many arguments" errors
+        $splitViews = $manager->splits();
+        $this->assertCount(0, $splitViews);
+    }
+}


### PR DESCRIPTION
# PHP SDK

## What did you accomplish?

Resolved an incorrect argument count when constructing SplitView inside LocalhostSplitManager.

This was a 100% failure rate code path that made local mode impossible to use in 7.3.0 (haven't validated earlier versions, but the line was committed 21 months prior).

## How do we test the changes introduced in this PR?

A new test was added to the tests suite. This ensure the failure mode does not exist and serves as a regression test for LocalhostSplitManager going forward.

## Extra Notes

Closes #240.
